### PR TITLE
Multiple things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.o
+*.a
+src/owfuzz

--- a/owfuzz/linux_wifi/trans/osdep_wifi_transmit.c
+++ b/owfuzz/linux_wifi/trans/osdep_wifi_transmit.c
@@ -177,7 +177,7 @@ int osdep_start_ex(struct osdep_instance *oi)
 int osdep_send_packet_ex(struct osdep_instance *oi, struct packet *pkt)
 {
 	struct wif *wi = oi->_wi_out; /* XXX globals suck */
-	if (wi_write(wi, pkt->data, pkt->len, NULL) == -1)
+	if (-1 == wi_write(wi, pkt->data, pkt->len, NULL))
 	{
 		switch (errno)
 		{

--- a/owfuzz/linux_wifi/trans/osdep_wifi_transmit.c
+++ b/owfuzz/linux_wifi/trans/osdep_wifi_transmit.c
@@ -5,7 +5,6 @@
 
 #include "osdep_wifi_transmit.h"
 
-
 int osdep_sockfd_in = -1;
 int osdep_sockfd_out = -1;
 
@@ -19,22 +18,24 @@ struct devices dev = {0};
 int osdep_start(char *interface1, char *interface2)
 {
 
-    osdep_iface_in = malloc(strlen(interface1) + 1);
-    strcpy(osdep_iface_in, interface1);
+	osdep_iface_in = malloc(strlen(interface1) + 1);
+	strcpy(osdep_iface_in, interface1);
 
 	osdep_iface_out = malloc(strlen(interface2) + 1);
-    strcpy(osdep_iface_out, interface2);
+	strcpy(osdep_iface_out, interface2);
 
 	/* open the replay interface */
 	_wi_out = wi_open(interface2);
-	if (!_wi_out){
+	if (!_wi_out)
+	{
 		printf("open interface %s failed.\n", interface2);
 		return 1;
 	}
 
 	dev.fd_out = wi_fd(_wi_out);
 
-	if(!strcmp(interface1, interface2)){
+	if (!strcmp(interface1, interface2))
+	{
 
 		/* open the packet source */
 		_wi_in = _wi_out;
@@ -43,11 +44,13 @@ int osdep_start(char *interface1, char *interface2)
 		/* XXX */
 		dev.arptype_in = dev.arptype_out;
 	}
-	else{
+	else
+	{
 
 		/* open the packet source */
 		_wi_in = wi_open(interface1);
-		if (!_wi_in){
+		if (!_wi_in)
+		{
 			printf("open interface %s failed.\n", interface1);
 			return 1;
 		}
@@ -55,15 +58,16 @@ int osdep_start(char *interface1, char *interface2)
 		dev.fd_in = wi_fd(_wi_in);
 	}
 
-    return 0;
+	return 0;
 }
-
 
 int osdep_send_packet(struct packet *pkt)
 {
 	struct wif *wi = _wi_out; /* XXX globals suck */
-	if (wi_write(wi, pkt->data, pkt->len, NULL) == -1) {
-		switch (errno) {
+	if (wi_write(wi, pkt->data, pkt->len, NULL) == -1)
+	{
+		switch (errno)
+		{
 		case EAGAIN:
 		case ENOBUFS:
 			usleep(10000);
@@ -77,65 +81,71 @@ int osdep_send_packet(struct packet *pkt)
 	return 0;
 }
 
-
 struct packet osdep_read_packet()
 {
 	struct wif *wi = _wi_in; /* XXX */
 	int rc;
-	struct packet pkt={0};
+	struct packet pkt = {0};
 
-	do {
-	  rc = wi_read(wi, pkt.data, MAX_IEEE_PACKET_SIZE, &pkt.ri);
-	  if (rc == -1) {
-	    perror("wi_read()");
-	    pkt.len = 0;
-	    return pkt;
-	  }
+	do
+	{
+		rc = wi_read(wi, pkt.data, MAX_IEEE_PACKET_SIZE, &pkt.ri);
+		if (rc == -1)
+		{
+			perror("wi_read()");
+			pkt.len = 0;
+			return pkt;
+		}
 	} while (rc < 1);
 
 	pkt.len = rc;
 	return pkt;
 }
 
-
 void osdep_stop()
 {
-	if(_wi_in){
+	if (_wi_in)
+	{
 		wi_close(_wi_in);
 		_wi_in = NULL;
 	}
 
-	if(_wi_out && (_wi_in != _wi_out)){
+	if (_wi_out && (_wi_in != _wi_out))
+	{
 		wi_close(_wi_out);
 		_wi_out = NULL;
 	}
 
-	if(osdep_iface_in){
+	if (osdep_iface_in)
+	{
 		free(osdep_iface_in);
 		osdep_iface_in = NULL;
 	}
 
-	if(osdep_iface_out){
+	if (osdep_iface_out)
+	{
 		free(osdep_iface_out);
 		osdep_iface_out = NULL;
 	}
 }
 
-
 int osdep_start_ex(struct osdep_instance *oi)
 {
-	if(oi == NULL) return -1;
+	if (oi == NULL)
+		return -1;
 
 	/* open the replay interface */
 	oi->_wi_out = wi_open(oi->osdep_iface_out);
-	if (!oi->_wi_out){
+	if (!oi->_wi_out)
+	{
 		printf("open interface %s failed.\n", oi->osdep_iface_out);
 		return -1;
 	}
 
 	oi->dev.fd_out = wi_fd(oi->_wi_out);
 
-	if(!strcmp(oi->osdep_iface_in, oi->osdep_iface_out)){
+	if (!strcmp(oi->osdep_iface_in, oi->osdep_iface_out))
+	{
 
 		/* open the packet source */
 		oi->_wi_in = oi->_wi_out;
@@ -146,27 +156,31 @@ int osdep_start_ex(struct osdep_instance *oi)
 
 		return 0;
 	}
-	else if(strlen(oi->osdep_iface_in)){
+	else if (strlen(oi->osdep_iface_in))
+	{
 
 		/* open the packet source */
 		oi->_wi_in = wi_open(oi->osdep_iface_in);
-		if (!oi->_wi_in){
+		if (!oi->_wi_in)
+		{
 			printf("open interface %s failed.\n", oi->osdep_iface_in);
 			return -1;
 		}
 
 		oi->dev.fd_in = wi_fd(oi->_wi_in);
 		return 0;
-	}		
+	}
 
 	return -1;
 }
 
-int osdep_send_packet_ex(struct osdep_instance* oi, struct packet *pkt)
+int osdep_send_packet_ex(struct osdep_instance *oi, struct packet *pkt)
 {
 	struct wif *wi = oi->_wi_out; /* XXX globals suck */
-	if (wi_write(wi, pkt->data, pkt->len, NULL) == -1) {
-		switch (errno) {
+	if (wi_write(wi, pkt->data, pkt->len, NULL) == -1)
+	{
+		switch (errno)
+		{
 		case EAGAIN:
 		case ENOBUFS:
 			usleep(10000);
@@ -183,19 +197,21 @@ int osdep_send_packet_ex(struct osdep_instance* oi, struct packet *pkt)
 /*
 	Read a packet from the WiFi interface
 */
-struct packet osdep_read_packet_ex(struct osdep_instance* oi)
+struct packet osdep_read_packet_ex(struct osdep_instance *oi)
 {
 	struct wif *wi = oi->_wi_in; /* XXX */
 	int rc;
 	struct packet pkt = {0};
 
-	do {
-	  rc = wi_read(wi, pkt.data, MAX_IEEE_PACKET_SIZE, &pkt.ri);
-	  if (rc == -1) {
-	    perror("wi_read()");
-	    pkt.len = 0;
-	    return pkt;
-	  }
+	do
+	{
+		rc = wi_read(wi, pkt.data, MAX_IEEE_PACKET_SIZE, &pkt.ri);
+		if (-1 == rc)
+		{
+			perror("wi_read()");
+			pkt.len = 0;
+			return pkt;
+		}
 	} while (rc < 1);
 
 	pkt.len = rc;
@@ -204,15 +220,18 @@ struct packet osdep_read_packet_ex(struct osdep_instance* oi)
 	return pkt;
 }
 
-void osdep_stop_ex(struct osdep_instance* oi)
+void osdep_stop_ex(struct osdep_instance *oi)
 {
-	if(oi){
-		if(oi->_wi_in){
+	if (oi != NULL)
+	{
+		if (oi->_wi_in != NULL)
+		{
 			wi_close(oi->_wi_in);
 			oi->_wi_in = NULL;
 		}
 
-		if(oi->_wi_out && (oi->_wi_in != oi->_wi_out)){
+		if (oi->_wi_out != NULL && (oi->_wi_in != oi->_wi_out))
+		{
 			wi_close(oi->_wi_out);
 			oi->_wi_out = NULL;
 		}

--- a/owfuzz/src/Makefile
+++ b/owfuzz/src/Makefile
@@ -9,19 +9,27 @@ CFLAGS+= -g
 
 SUBDIRS = frames common procedures
 
-FRAMEOBJ = ./common/queue.o ./common/config.o ./common/pcap_log.o ./common/log.o ./common/mac_addr.o ./frames/frame.o ./frames/80211_packet_common.o ./frames/management/beacon.o ./frames/management/ies_creator.o \
-./frames/management/probe_response.o ./frames/management/association_response.o ./frames/management/reassociation_response.o \
-./frames/management/timing_advertisement.o ./frames/management/authentication.o ./frames/management/action.o ./frames/management/deauthentication.o \
-./frames/management/disassociation.o ./frames/management/action_no_ack.o ./frames/management/association_request.o ./frames/management/reassociation_request.o \
-./frames/management/probe_request.o ./frames/management/atim.o \
-./frames/control/acknowledgement.o ./frames/control/beamforming_report_poll.o ./frames/control/block_ack_request.o ./frames/control/block_ack.o ./frames/control/cf_end_cf_ack.o ./frames/control/cf_end.o ./frames/control/control_frame_extension.o \
-./frames/control/control_wrapper.o ./frames/control/cts.o ./frames/control/ps_poll.o ./frames/control/rts.o ./frames/control/vht_ndp_announcement.o \
-./frames/data/qos_data.o ./frames/data/data.o ./frames/data/d_cf_ack_poll.o ./frames/data/d_cf_ack.o ./frames/data/d_cf_poll.o ./frames/data/data_cf_ack_poll.o \
-./frames/data/data_cf_ack.o ./frames/data/data_cf_poll.o ./frames/data/data_null.o ./frames/data/qos_cf_ack_poll.o ./frames/data/qos_cf_poll.o ./frames/data/qos_cf_ack.o \
-./frames/data/qos_data_cf_ack_poll.o ./frames/data/qos_data_cf_ack.o ./frames/data/qos_data_cf_poll.o ./frames/data/qos_null.o \
-./procedures/direct/direct.o ./procedures/awdl/awdl.o ./procedures/awdl/awdl_frame.o ./procedures/awdl/wire.o ./procedures/mesh/mesh.o
+FRAMEOBJ = 	./common/queue.o ./common/config.o ./common/pcap_log.o ./common/log.o \
+			./common/mac_addr.o ./frames/frame.o ./frames/80211_packet_common.o \
+			./frames/management/beacon.o ./frames/management/ies_creator.o \
+			./frames/management/probe_response.o ./frames/management/association_response.o ./frames/management/reassociation_response.o \
+			./frames/management/timing_advertisement.o ./frames/management/authentication.o ./frames/management/action.o ./frames/management/deauthentication.o \
+			./frames/management/disassociation.o ./frames/management/action_no_ack.o ./frames/management/association_request.o \
+			./frames/management/reassociation_request.o \
+			./frames/management/probe_request.o ./frames/management/atim.o \
+			./frames/control/acknowledgement.o ./frames/control/beamforming_report_poll.o ./frames/control/block_ack_request.o ./frames/control/block_ack.o \
+			./frames/control/cf_end_cf_ack.o ./frames/control/cf_end.o ./frames/control/control_frame_extension.o \
+			./frames/control/control_wrapper.o ./frames/control/cts.o ./frames/control/ps_poll.o ./frames/control/rts.o \
+			./frames/control/vht_ndp_announcement.o \
+			./frames/data/qos_data.o ./frames/data/data.o ./frames/data/d_cf_ack_poll.o ./frames/data/d_cf_ack.o ./frames/data/d_cf_poll.o \
+			./frames/data/data_cf_ack_poll.o \
+			./frames/data/data_cf_ack.o ./frames/data/data_cf_poll.o ./frames/data/data_null.o ./frames/data/qos_cf_ack_poll.o ./frames/data/qos_cf_poll.o \
+			./frames/data/qos_cf_ack.o \
+			./frames/data/qos_data_cf_ack_poll.o ./frames/data/qos_data_cf_ack.o ./frames/data/qos_data_cf_poll.o ./frames/data/qos_null.o \
+			./procedures/direct/direct.o ./procedures/awdl/awdl.o ./procedures/awdl/awdl_frame.o ./procedures/awdl/wire.o ./procedures/mesh/mesh.o \
 
-OBJS = owfuzz.o fuzz_control.o
+
+OBJS = owfuzz.o fuzz_control.o hashtable.o
 
 all: subdir owfuzz
 

--- a/owfuzz/src/common/config.c
+++ b/owfuzz/src/common/config.c
@@ -627,9 +627,12 @@ int owfuzz_config_get_interfaces(char *cfg_file, fuzzing_option *fo)
 	return 0;
 }
 
+/*
+	Retrieve from the cfg_file the 'interfaces' section
+*/
 int owfuzz_config_get_channels(char *cfg_file, fuzzing_option *fo)
 {
-	FILE *fp1;
+	FILE *fp1 = NULL;
 	char buf[256] = {0};
 	char iface[64] = {0};
 	int rc = 0;
@@ -687,7 +690,7 @@ int owfuzz_config_get_channels(char *cfg_file, fuzzing_option *fo)
 
 int owfuzz_config_get_macs(char *cfg_file, fuzzing_option *fo)
 {
-	FILE *fp1;
+	FILE *fp1 = NULL;
 	char buf[512] = {0};
 	char option_name[256] = {0};
 	char option_value[256] = {0};
@@ -736,15 +739,17 @@ int owfuzz_config_get_macs(char *cfg_file, fuzzing_option *fo)
 
 				fuzz_logger_log(FUZZ_LOG_DEBUG, "option_name: %s, option_value: %s", option_name, option_value);
 
-				if (!strcmp(option_name, "target_mac"))
+				if (0 == strcmp(option_name, "target_mac"))
 				{
 					fo->target_addr = parse_mac(option_value);
 				}
-				else if (!strcmp(option_name, "bssid"))
+
+				if (0 == strcmp(option_name, "bssid"))
 				{
 					fo->bssid = parse_mac(option_value);
 				}
-				else if (!strcmp(option_name, "source_mac"))
+
+				if (0 == strcmp(option_name, "source_mac"))
 				{
 					fo->source_addr = parse_mac(option_value);
 				}
@@ -803,7 +808,8 @@ int owfuzz_config_get_fuzzing_option(char *cfg_file, fuzzing_option *fo)
 				memset(option_name, 0, sizeof(option_name));
 				memset(option_value, 0, sizeof(option_value));
 
-				sscanf(buf, "%[^=]=%s", option_name, option_value);
+				// We want to cpature everything including spaces (i.e. a ssid might have a space), so we use [^\n] instead of %s
+				sscanf(buf, "%[^=]=%[^\n]", option_name, option_value);
 
 				fuzz_logger_log(FUZZ_LOG_DEBUG, "option_name: %s, option_value: %s", option_name, option_value);
 
@@ -863,7 +869,7 @@ int owfuzz_config_get_fuzzing_option(char *cfg_file, fuzzing_option *fo)
 						}
 					}
 				}
-				else if (!strcmp(option_name, "ssid"))
+				else if (0 == strcmp(option_name, "ssid"))
 				{
 					if (strlen(option_value) > 32)
 					{
@@ -873,7 +879,9 @@ int owfuzz_config_get_fuzzing_option(char *cfg_file, fuzzing_option *fo)
 					}
 
 					if (strlen(option_value) != 0)
+					{
 						strncpy(fo->target_ssid, option_value, sizeof(fo->target_ssid) - 1);
+					}
 				}
 				else if (!strcmp(option_name, "auth_type"))
 				{

--- a/owfuzz/src/common/include.h
+++ b/owfuzz/src/common/include.h
@@ -116,6 +116,20 @@ static const char *AP_AUTH_TYPE_NAME[] =
 	"WPA3"
 };
 
+static const char *wpa_state_names[] = {
+	"WPA_DISCONNECTED",
+	"WPA_INTERFACE_DISABLED",
+	"WPA_INACTIVE",
+	"WPA_SCANNING",
+	"WPA_AUTHENTICATING",
+	"WPA_ASSOCIATING",
+	"WPA_ASSOCIATED",
+	"WPA_EAP_HANDSHAKE",
+	"WPA_4WAY_HANDSHAKE",
+	"WPA_GROUP_HANDSHAKE",
+	"WPA_COMPLETED"
+};
+
 /**
  * enum wpa_states - wpa_supplicant state
  *

--- a/owfuzz/src/frames/80211_packet_common.c
+++ b/owfuzz/src/frames/80211_packet_common.c
@@ -267,13 +267,16 @@ void set_fragno(struct packet *pkt, uint8_t frag, int last_frag)
 	hdr->frag_seq = htole16(seq);
 }
 
+/*
+	Returns the adddress of the packet
+*/
 struct ether_addr *get_addr(struct packet *pkt, char type)
 {
-	uint8_t dsflags;
-	struct ieee_hdr *hdr;
+	uint8_t dsflags = 0;
+	struct ieee_hdr *hdr = NULL;
 	struct ether_addr *src = NULL, *dst = NULL, *bss = NULL, *trn = NULL;
 
-	if (!pkt)
+	if (NULL == pkt)
 	{
 		printf("BUG: Got NULL packet!\n");
 		return NULL;
@@ -349,11 +352,11 @@ struct ether_addr *get_receiver(struct packet *pkt)
 
 uint8_t *get_elemet(struct packet *pkt, uint8_t id)
 {
-	struct ieee_hdr *hdr;
+	struct ieee_hdr *hdr = NULL;
 	unsigned char *ie = NULL;
-	int left;
+	int left = 0;
 
-	if (!pkt)
+	if (NULL == pkt)
 	{
 		fuzz_logger_log(FUZZ_LOG_INFO, "get_elemet: pkt is NULL");
 		return NULL;
@@ -410,7 +413,7 @@ uint8_t *get_elemet(struct packet *pkt, uint8_t id)
 		break;
 	}
 
-	if (ie)
+	if (NULL != ie)
 	{
 		left = pkt->len - (ie - pkt->data);
 		while (left > 2)

--- a/owfuzz/src/frames/control/acknowledgement.c
+++ b/owfuzz/src/frames/control/acknowledgement.c
@@ -22,7 +22,7 @@
 struct packet create_ack(struct ether_addr dmac)
 {
     struct packet pkt = {0};
-    struct ieee_hdr *hdr;
+    struct ieee_hdr *hdr = NULL;
 
     hdr = (struct ieee_hdr *)pkt.data;
     hdr->type = IEEE80211_TYPE_ACK;
@@ -38,7 +38,8 @@ struct packet create_ack(struct ether_addr dmac)
 
     // dumphex(pkt.data, pkt.len);
 
-    fuzz_logger_log(FUZZ_LOG_DEBUG, "Response Ack to  ==> %02X:%02X:%02X:%02X:%02X:%02X",
+    fuzz_logger_log(FUZZ_LOG_DEBUG, "[%s:%d] (Unmodified) Response Ack to  ==> %02X:%02X:%02X:%02X:%02X:%02X",
+                    __FILE__, __LINE__,
                     dmac.ether_addr_octet[0],
                     dmac.ether_addr_octet[1],
                     dmac.ether_addr_octet[2],

--- a/owfuzz/src/frames/frame.c
+++ b/owfuzz/src/frames/frame.c
@@ -145,7 +145,7 @@ struct packet get_frame(uint8_t frame_type, struct ether_addr bssid, struct ethe
 
 	fuzzing_opt.current_frame = frame_type;
 
-	fuzz_logger_log(FUZZ_LOG_INFO, "[%s:%d] frame_type: %x (%s)", __FILE__, __LINE__, frame_type, return_frame_type(frame_type));
+	// fuzz_logger_log(FUZZ_LOG_INFO, "[%s:%d] frame_type: %x (%s)", __FILE__, __LINE__, frame_type, return_frame_type(frame_type));
 	switch (frame_type)
 	{
 	// management

--- a/owfuzz/src/frames/frame.c
+++ b/owfuzz/src/frames/frame.c
@@ -28,6 +28,111 @@
 
 extern fuzzing_option fuzzing_opt;
 
+const char *return_frame_type(uint8_t frame_type)
+{
+	switch (frame_type)
+	{
+	// management
+	case IEEE80211_TYPE_ASSOCRES: // AP
+		return "IEEE80211_TYPE_ASSOCRES";
+	case IEEE80211_TYPE_REASSOCRES:
+		return "IEEE80211_TYPE_REASSOCRES";
+	case IEEE80211_TYPE_PROBERES:
+		return "IEEE80211_TYPE_PROBERES";
+	case IEEE80211_TYPE_TIMADVERT:
+		return "IEEE80211_TYPE_TIMADVERT";
+	case IEEE80211_TYPE_BEACON:
+		return "IEEE80211_TYPE_BEACON";
+	case IEEE80211_TYPE_ATIM: // xx
+		return "IEEE80211_TYPE_ATIM";
+	case IEEE80211_TYPE_DISASSOC:
+		return "IEEE80211_TYPE_DISASSOC";
+	case IEEE80211_TYPE_DEAUTH:
+		return "IEEE80211_TYPE_DEAUTH";
+	case IEEE80211_TYPE_ACTION:
+		return "IEEE80211_TYPE_ACTION";
+	case IEEE80211_TYPE_ACTIONNOACK:
+		return "IEEE80211_TYPE_ACTIONNOACK";
+	case IEEE80211_TYPE_ASSOCREQ: // STA
+		return "IEEE80211_TYPE_ASSOCREQ";
+	case IEEE80211_TYPE_REASSOCREQ:
+		return "IEEE80211_TYPE_REASSOCREQ";
+	case IEEE80211_TYPE_PROBEREQ:
+		return "IEEE80211_TYPE_PROBEREQ";
+	case IEEE80211_TYPE_AUTH:
+		return "IEEE80211_TYPE_AUTH";
+
+	// control
+	case IEEE80211_TYPE_ACK:
+		return "IEEE80211_TYPE_ACK";
+	case IEEE80211_TYPE_BEAMFORMING:
+		return "IEEE80211_TYPE_BEAMFORMING";
+	case IEEE80211_TYPE_VHT:
+		return "IEEE80211_TYPE_VHT";
+	case IEEE80211_TYPE_CTRLFRMEXT:
+		return "IEEE80211_TYPE_CTRLFRMEXT";
+	case IEEE80211_TYPE_CTRLWRAP:
+		return "IEEE80211_TYPE_CTRLWRAP";
+	case IEEE80211_TYPE_BLOCKACKREQ:
+		return "IEEE80211_TYPE_BLOCKACKREQ";
+	case IEEE80211_TYPE_BLOCKACK:
+		return "IEEE80211_TYPE_BLOCKACK";
+	case IEEE80211_TYPE_PSPOLL:
+		return "IEEE80211_TYPE_PSPOLL";
+	case IEEE80211_TYPE_RTS:
+		return "IEEE80211_TYPE_RTS";
+	case IEEE80211_TYPE_CTS:
+		return "IEEE80211_TYPE_CTS";
+	case IEEE80211_TYPE_CFEND:
+		return "IEEE80211_TYPE_CFEND";
+	case IEEE80211_TYPE_CFENDACK:
+		return "IEEE80211_TYPE_CFENDACK";
+
+	// data
+	case IEEE80211_TYPE_QOSDATA:
+		return "IEEE80211_TYPE_QOSDATA";
+	case IEEE80211_TYPE_DATA:
+		return "IEEE80211_TYPE_DATA";
+	case IEEE80211_TYPE_DATACFACK:
+		return "IEEE80211_TYPE_DATACFACK";
+	case IEEE80211_TYPE_DATACFPOLL:
+		return "IEEE80211_TYPE_DATACFPOLL";
+	case IEEE80211_TYPE_DATACFACKPOLL:
+		return "IEEE80211_TYPE_DATACFACKPOLL";
+	case IEEE80211_TYPE_NULL:
+		return "IEEE80211_TYPE_NULL";
+	case IEEE80211_TYPE_CFACK:
+		return "IEEE80211_TYPE_CFACK";
+	case IEEE80211_TYPE_CFPOLL:
+		return "IEEE80211_TYPE_CFPOLL";
+	case IEEE80211_TYPE_CFACKPOLL:
+		return "IEEE80211_TYPE_CFACKPOLL";
+	case IEEE80211_TYPE_QOSDATACFACK:
+		return "IEEE80211_TYPE_QOSDATACFACK";
+	case IEEE80211_TYPE_QOSDATACFPOLL:
+		return "IEEE80211_TYPE_QOSDATACFPOLL";
+	case IEEE80211_TYPE_QOSDATACFACKPOLL:
+		return "IEEE80211_TYPE_QOSDATACFACKPOLL";
+	case IEEE80211_TYPE_QOSNULL:
+		return "IEEE80211_TYPE_QOSNULL";
+	case IEEE80211_TYPE_QOSCFACK:
+		return "IEEE80211_TYPE_QOSCFACK";
+	case IEEE80211_TYPE_QOSCFPOLL:
+		return "IEEE80211_TYPE_QOSCFPOLL";
+	case IEEE80211_TYPE_QOSCFACKPOLL:
+		return "IEEE80211_TYPE_QOSCFACKPOLL";
+
+	// extension
+	case IEEE80211_TYPE_DMGBEACON:
+		return "IEEE80211_TYPE_DMGBEACON";
+	}
+
+	return "UNKNOWN";
+}
+
+/*
+	Return a pkt frame - fuzzed
+*/
 struct packet get_frame(uint8_t frame_type, struct ether_addr bssid, struct ether_addr smac, struct ether_addr dmac, struct packet *recv_pkt)
 {
 	struct packet pkt = {0};
@@ -40,6 +145,7 @@ struct packet get_frame(uint8_t frame_type, struct ether_addr bssid, struct ethe
 
 	fuzzing_opt.current_frame = frame_type;
 
+	fuzz_logger_log(FUZZ_LOG_INFO, "[%s:%d] frame_type: %x (%s)", __FILE__, __LINE__, frame_type, return_frame_type(frame_type));
 	switch (frame_type)
 	{
 	// management
@@ -677,11 +783,13 @@ void log_pkt(int log_level, struct packet *pkt)
 	int log_txt_len = 0, len = 0;
 	char buf[MAX_PRINT_BUF_LEN * 5] = {0};
 
-	if (log_level > fuzzing_opt.log_level) {
+	if (log_level > fuzzing_opt.log_level)
+	{
 		return;
 	}
 
-	if (pkt->data[0] == 0 || pkt->len <= 0) {
+	if (pkt->data[0] == 0 || pkt->len <= 0)
+	{
 		return;
 	}
 

--- a/owfuzz/src/fuzz_control.c
+++ b/owfuzz/src/fuzz_control.c
@@ -2262,18 +2262,10 @@ void *start_fuzzing(void *param)
 					ht_insert(ht_notification_hash, smac_address, "notified");
 					ht_insert(ht_notification_hash, dmac_address, "notified");
 					fuzz_logger_log(FUZZ_LOG_INFO,
-									"[%s:%d] Packet is not for us.. smac %s, dmac %s"
-									"\n[%s:%d] Make packets for us.. target %02X:%02X:%02X:%02X:%02X:%02X, source %02X:%02X:%02X:%02X:%02X:%02X",
+									"[%s:%d] Packet is not for us.. smac %s, dmac %s",
 									__FILE__, __LINE__,
 									smac_address,
-									dmac_address,
-									__FILE__, __LINE__,
-									fuzzing_opt->target_addr.ether_addr_octet[0], fuzzing_opt->target_addr.ether_addr_octet[1],
-									fuzzing_opt->target_addr.ether_addr_octet[2], fuzzing_opt->target_addr.ether_addr_octet[3],
-									fuzzing_opt->target_addr.ether_addr_octet[4], fuzzing_opt->target_addr.ether_addr_octet[5],
-									fuzzing_opt->source_addr.ether_addr_octet[0], fuzzing_opt->source_addr.ether_addr_octet[1],
-									fuzzing_opt->source_addr.ether_addr_octet[2], fuzzing_opt->source_addr.ether_addr_octet[3],
-									fuzzing_opt->source_addr.ether_addr_octet[4], fuzzing_opt->source_addr.ether_addr_octet[5]);
+									dmac_address);
 				}
 			}
 			continue;
@@ -2423,19 +2415,11 @@ void *start_fuzzing(void *param)
 						ht_insert(ht_notification_hash, smac_address, "notified");
 						ht_insert(ht_notification_hash, dmac_address, "notified");
 						fuzz_logger_log(FUZZ_LOG_INFO,
-										"[%s:%d] Packet is not for us.. smac %s, dmac %s, frame_name: '%s'"
-										"\n[%s:%d] Make packets for us.. target %02X:%02X:%02X:%02X:%02X:%02X, source %02X:%02X:%02X:%02X:%02X:%02X",
+										"[%s:%d] Packet is not for us.. smac %s, dmac %s, frame_name: '%s'",
 										__FILE__, __LINE__,
-										frame_name,
 										smac_address,
 										dmac_address,
-										__FILE__, __LINE__,
-										fuzzing_opt->target_addr.ether_addr_octet[0], fuzzing_opt->target_addr.ether_addr_octet[1],
-										fuzzing_opt->target_addr.ether_addr_octet[2], fuzzing_opt->target_addr.ether_addr_octet[3],
-										fuzzing_opt->target_addr.ether_addr_octet[4], fuzzing_opt->target_addr.ether_addr_octet[5],
-										fuzzing_opt->source_addr.ether_addr_octet[0], fuzzing_opt->source_addr.ether_addr_octet[1],
-										fuzzing_opt->source_addr.ether_addr_octet[2], fuzzing_opt->source_addr.ether_addr_octet[3],
-										fuzzing_opt->source_addr.ether_addr_octet[4], fuzzing_opt->source_addr.ether_addr_octet[5]);
+										frame_name);
 					}
 				}
 			}

--- a/owfuzz/src/fuzz_control.c
+++ b/owfuzz/src/fuzz_control.c
@@ -643,7 +643,7 @@ int send_packet_ex(struct packet *pkt)
 				if (fuzzing_opt.ois[ois_number].channel == pkt->channel)
 				{
 					fuzzing_opt.fuzz_pkt_num++;
-					fuzz_logger_log(FUZZ_LOG_INFO, "[%s:%d] fuzzing_opt.fuzz_pkt_num: %d, channel: %d --> send packet: %d", __FILE__, __LINE__, fuzzing_opt.fuzz_pkt_num, pkt->channel, pkt->len);
+					fuzz_logger_log(FUZZ_LOG_INFO, "[%s:%d] fuzzing_opt.fuzz_pkt_num: %d, channel: %d --> send packet len: %d", __FILE__, __LINE__, fuzzing_opt.fuzz_pkt_num, pkt->channel, pkt->len);
 					return osdep_send_packet_ex(&fuzzing_opt.ois[ois_number], pkt);
 				}
 			}
@@ -651,7 +651,7 @@ int send_packet_ex(struct packet *pkt)
 		else
 		{
 			fuzzing_opt.fuzz_pkt_num++;
-			fuzz_logger_log(FUZZ_LOG_INFO, "[%s:%d] fuzzing_opt.fuzz_pkt_num: %d, channel: %d --> send packet: %d", __FILE__, __LINE__, fuzzing_opt.fuzz_pkt_num, pkt->channel, pkt->len);
+			fuzz_logger_log(FUZZ_LOG_INFO, "[%s:%d] fuzzing_opt.fuzz_pkt_num: %d, channel: %d --> send packet len: %d", __FILE__, __LINE__, fuzzing_opt.fuzz_pkt_num, pkt->channel, pkt->len);
 
 			// dumphex(pkt->data, pkt->len);
 

--- a/owfuzz/src/fuzz_control.c
+++ b/owfuzz/src/fuzz_control.c
@@ -2165,7 +2165,7 @@ void *start_fuzzing(void *param)
 		}
 
 		frame_name = return_frame_name(hdr->type);
-		// printf("[%s:%d] fuzz_pkt_num: %d                 \r", __FILE__, __LINE__, fuzzing_opt->fuzz_pkt_num);
+		printf("[%s:%d] fuzz_pkt_num: %d                 \r", __FILE__, __LINE__, fuzzing_opt->fuzz_pkt_num);
 		// fuzz_logger_log(FUZZ_LOG_INFO, "recv-->%s", frame_name);
 
 		if (FUZZ_WORK_MODE_MITM != fuzzing_opt->fuzz_work_mode)

--- a/owfuzz/src/fuzz_control.c
+++ b/owfuzz/src/fuzz_control.c
@@ -2259,12 +2259,15 @@ void *start_fuzzing(void *param)
 
 				if (NULL == ht_search(ht_notification_hash, smac_address) || NULL == ht_search(ht_notification_hash, dmac_address))
 				{
-					create_item(ht_)
+					ht_insert(ht_notification_hash, smac_address, "notified");
+					ht_insert(ht_notification_hash, dmac_address, "notified");
 					fuzz_logger_log(FUZZ_LOG_INFO,
-									"Packet is not for us.. smac %s, dmac %s"
-									"\nMake packets for us.. target %02X:%02X:%02X:%02X:%02X:%02X, source %02X:%02X:%02X:%02X:%02X:%02X",
+									"[%s:%d] Packet is not for us.. smac %s, dmac %s"
+									"\n[%s:%d] Make packets for us.. target %02X:%02X:%02X:%02X:%02X:%02X, source %02X:%02X:%02X:%02X:%02X:%02X",
+									__FILE__, __LINE__,
 									smac_address,
 									dmac_address,
+									__FILE__, __LINE__,
 									fuzzing_opt->target_addr.ether_addr_octet[0], fuzzing_opt->target_addr.ether_addr_octet[1],
 									fuzzing_opt->target_addr.ether_addr_octet[2], fuzzing_opt->target_addr.ether_addr_octet[3],
 									fuzzing_opt->target_addr.ether_addr_octet[4], fuzzing_opt->target_addr.ether_addr_octet[5],
@@ -2404,24 +2407,36 @@ void *start_fuzzing(void *param)
 				{
 					// Skip those that are broadcast, they are not relevant for us
 					// Notify user if the settings don't match..
-					fuzz_logger_log(FUZZ_LOG_INFO,
-									"[%s:%d] Packet, frame_name: '%s', is not for us.. smac %02X:%02X:%02X:%02X:%02X:%02X, dmac %02X:%02X:%02X:%02X:%02X:%02X"
-									"\n[%s:%d] Make packets for us.. target %02X:%02X:%02X:%02X:%02X:%02X, source %02X:%02X:%02X:%02X:%02X:%02X",
-									__FILE__, __LINE__,
-									frame_name,
-									smac.ether_addr_octet[0], smac.ether_addr_octet[1],
-									smac.ether_addr_octet[2], smac.ether_addr_octet[3],
-									smac.ether_addr_octet[4], smac.ether_addr_octet[5],
-									dmac.ether_addr_octet[0], dmac.ether_addr_octet[1],
-									dmac.ether_addr_octet[2], dmac.ether_addr_octet[3],
-									dmac.ether_addr_octet[4], dmac.ether_addr_octet[5],
-									__FILE__, __LINE__,
-									fuzzing_opt->target_addr.ether_addr_octet[0], fuzzing_opt->target_addr.ether_addr_octet[1],
-									fuzzing_opt->target_addr.ether_addr_octet[2], fuzzing_opt->target_addr.ether_addr_octet[3],
-									fuzzing_opt->target_addr.ether_addr_octet[4], fuzzing_opt->target_addr.ether_addr_octet[5],
-									fuzzing_opt->source_addr.ether_addr_octet[0], fuzzing_opt->source_addr.ether_addr_octet[1],
-									fuzzing_opt->source_addr.ether_addr_octet[2], fuzzing_opt->source_addr.ether_addr_octet[3],
-									fuzzing_opt->source_addr.ether_addr_octet[4], fuzzing_opt->source_addr.ether_addr_octet[5]);
+					char smac_address[128] = {0};
+					char dmac_address[128] = {0};
+					sprintf(smac_address, "%02X:%02X:%02X:%02X:%02X:%02X", smac.ether_addr_octet[0], smac.ether_addr_octet[1],
+							smac.ether_addr_octet[2], smac.ether_addr_octet[3],
+							smac.ether_addr_octet[4], smac.ether_addr_octet[5]);
+
+					sprintf(dmac_address, "%02X:%02X:%02X:%02X:%02X:%02X", dmac.ether_addr_octet[0], dmac.ether_addr_octet[1],
+							dmac.ether_addr_octet[2], dmac.ether_addr_octet[3],
+							dmac.ether_addr_octet[4], dmac.ether_addr_octet[5]);
+
+					if (NULL == ht_search(ht_notification_hash, smac_address) || NULL == ht_search(ht_notification_hash, dmac_address))
+					{
+						// print_table(ht_notification_hash);
+						ht_insert(ht_notification_hash, smac_address, "notified");
+						ht_insert(ht_notification_hash, dmac_address, "notified");
+						fuzz_logger_log(FUZZ_LOG_INFO,
+										"[%s:%d] Packet is not for us.. smac %s, dmac %s, frame_name: '%s'"
+										"\n[%s:%d] Make packets for us.. target %02X:%02X:%02X:%02X:%02X:%02X, source %02X:%02X:%02X:%02X:%02X:%02X",
+										__FILE__, __LINE__,
+										frame_name,
+										smac_address,
+										dmac_address,
+										__FILE__, __LINE__,
+										fuzzing_opt->target_addr.ether_addr_octet[0], fuzzing_opt->target_addr.ether_addr_octet[1],
+										fuzzing_opt->target_addr.ether_addr_octet[2], fuzzing_opt->target_addr.ether_addr_octet[3],
+										fuzzing_opt->target_addr.ether_addr_octet[4], fuzzing_opt->target_addr.ether_addr_octet[5],
+										fuzzing_opt->source_addr.ether_addr_octet[0], fuzzing_opt->source_addr.ether_addr_octet[1],
+										fuzzing_opt->source_addr.ether_addr_octet[2], fuzzing_opt->source_addr.ether_addr_octet[3],
+										fuzzing_opt->source_addr.ether_addr_octet[4], fuzzing_opt->source_addr.ether_addr_octet[5]);
+					}
 				}
 			}
 		}

--- a/owfuzz/src/fuzz_control.c
+++ b/owfuzz/src/fuzz_control.c
@@ -433,7 +433,7 @@ void sniff_ies(struct packet *pkt)
 		return;
 	}
 
-	if (tlvs && tlvs_len != 0)
+	if (NULL != tlvs && tlvs_len != 0)
 	{
 		idx = 0;
 		for (i = 0; i < MAX_SFS_COUNT; i++)
@@ -643,7 +643,7 @@ int send_packet_ex(struct packet *pkt)
 				if (fuzzing_opt.ois[ois_number].channel == pkt->channel)
 				{
 					fuzzing_opt.fuzz_pkt_num++;
-					// fuzz_logger_log(FUZZ_LOG_INFO, "[%s:%d] channel: %d --> send packet: %d", __FILE__, __LINE__, pkt->channel, pkt->len);
+					fuzz_logger_log(FUZZ_LOG_INFO, "[%s:%d] fuzzing_opt.fuzz_pkt_num: %d, channel: %d --> send packet: %d", __FILE__, __LINE__, fuzzing_opt.fuzz_pkt_num, pkt->channel, pkt->len);
 					return osdep_send_packet_ex(&fuzzing_opt.ois[ois_number], pkt);
 				}
 			}
@@ -651,7 +651,10 @@ int send_packet_ex(struct packet *pkt)
 		else
 		{
 			fuzzing_opt.fuzz_pkt_num++;
-			fuzz_logger_log(FUZZ_LOG_DEBUG, "[%s:%d] channel: %d --> send packet: %d", __FILE__, __LINE__, pkt->channel, pkt->len);
+			fuzz_logger_log(FUZZ_LOG_INFO, "[%s:%d] fuzzing_opt.fuzz_pkt_num: %d, channel: %d --> send packet: %d", __FILE__, __LINE__, fuzzing_opt.fuzz_pkt_num, pkt->channel, pkt->len);
+
+			// dumphex(pkt->data, pkt->len);
+
 			return osdep_send_packet_ex(&fuzzing_opt.ois[0], pkt);
 		}
 	}
@@ -2279,10 +2282,11 @@ void *start_fuzzing(void *param)
 					ht_insert(ht_notification_hash, smac_address, "notified");
 					ht_insert(ht_notification_hash, dmac_address, "notified");
 					fuzz_logger_log(FUZZ_LOG_INFO,
-									"[%s:%d] Packet is not for us.. smac %s, dmac %s",
+									"[%s:%d] Packet is not for us.. smac %s, dmac %s, frame_name: %s",
 									__FILE__, __LINE__,
 									smac_address,
-									dmac_address);
+									dmac_address,
+									frame_name);
 				}
 			}
 			continue;
@@ -2309,10 +2313,12 @@ void *start_fuzzing(void *param)
 			fuzzing_opt->target_alive = 1;
 		}
 
+		// fuzz_logger_log(FUZZ_LOG_INFO, "[%s:%d] fuzzing_opt->sniff_frames: %d", __FILE__, __LINE__, fuzzing_opt->sniff_frames);
 		if (1 == fuzzing_opt->sniff_frames /*FUZZ_WORK_MODE_AP == fuzzing_opt->fuzz_work_mode || FUZZ_WORK_MODE_STA == fuzzing_opt->fuzz_work_mode*/)
 		{
 			if (TEST_FRAME == fuzzing_opt->test_type)
 			{
+				// fuzz_logger_log(FUZZ_LOG_INFO, "[%s:%d] sniff_ies", __FILE__, __LINE__);
 				sniff_ies(&pkt);
 
 				// fuzz_logger_log(FUZZ_LOG_INFO, "fuzzing_opt->cur_sfs_cnt: %d", fuzzing_opt->cur_sfs_cnt);
@@ -2327,7 +2333,7 @@ void *start_fuzzing(void *param)
 				else
 				{
 					// We don't use fuzz_logger_log because we want it to stay on the same line
-					printf("Need more packets... have: %d, need: %d\r", fuzzing_opt->cur_sfs_cnt, CAPTURED_PKT_BEFORE_FUZZING);
+					printf("Need more packets... have: %d, need: %d               \r", fuzzing_opt->cur_sfs_cnt, CAPTURED_PKT_BEFORE_FUZZING);
 				}
 			}
 		}

--- a/owfuzz/src/fuzz_control.c
+++ b/owfuzz/src/fuzz_control.c
@@ -36,6 +36,7 @@
 #include "procedures/direct/direct.h"
 #include "procedures/awdl/awdl.h"
 #include "procedures/mesh/mesh.h"
+#include "hashtable.h"
 
 #define MAX_BAD_FRAME_COUNT 300
 struct packet *bad_frame = NULL;
@@ -49,6 +50,9 @@ struct ow_queue owq;
 pthread_mutex_t owq_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 #define DEAUTH_TIME 10
+
+// Define how many packets will be captured before fuzzing starts
+#define CAPTURED_PKT_BEFORE_FUZZING 3
 
 uint8_t owfuzz_frames[64] = {0};
 
@@ -137,6 +141,8 @@ uint8_t all_frames[] =
 		IEEE80211_TYPE_111110,
 		IEEE80211_TYPE_111111*/
 };
+
+HashTable *ht_notification_hash = NULL;
 
 void usage_help(char *name)
 {
@@ -616,32 +622,36 @@ struct packet read_packet_ex()
 	return pkt;
 }
 
+/*
+	Send a packet to the target
+*/
 int send_packet_ex(struct packet *pkt)
 {
-	int i = 0;
+	int ois_number = 0;
 
 	if (NULL != pkt)
 	{
 		// fuzzing_opt.fuzz_pkt = *pkt;
-		fuzz_logger_log(FUZZ_LOG_DEBUG, "channel: %d --> send packet: %d", pkt->channel, pkt->len);
 		log_pkt(FUZZ_LOG_DEBUG, pkt);
-		if (fuzzing_opt.test_type != 0 && fuzzing_opt.fuzz_work_mode != FUZZ_WORK_MODE_MITM)
+		if (fuzzing_opt.test_type != 0 && FUZZ_WORK_MODE_MITM != fuzzing_opt.fuzz_work_mode)
 			save_packet(pkt);
 
 		if (pkt->channel != 0)
 		{
-			for (i = 0; i < fuzzing_opt.ois_cnt; i++)
+			for (ois_number = 0; ois_number < fuzzing_opt.ois_cnt; ois_number++)
 			{
-				if (fuzzing_opt.ois[i].channel == pkt->channel)
+				if (fuzzing_opt.ois[ois_number].channel == pkt->channel)
 				{
 					fuzzing_opt.fuzz_pkt_num++;
-					return osdep_send_packet_ex(&fuzzing_opt.ois[i], pkt);
+					// fuzz_logger_log(FUZZ_LOG_INFO, "[%s:%d] channel: %d --> send packet: %d", __FILE__, __LINE__, pkt->channel, pkt->len);
+					return osdep_send_packet_ex(&fuzzing_opt.ois[ois_number], pkt);
 				}
 			}
 		}
 		else
 		{
 			fuzzing_opt.fuzz_pkt_num++;
+			fuzz_logger_log(FUZZ_LOG_DEBUG, "[%s:%d] channel: %d --> send packet: %d", __FILE__, __LINE__, pkt->channel, pkt->len);
 			return osdep_send_packet_ex(&fuzzing_opt.ois[0], pkt);
 		}
 	}
@@ -853,7 +863,7 @@ void handle_action(struct packet *pkt, struct ether_addr bssid, struct ether_add
 
 void handle_sta_auth(struct packet *pkt, struct ether_addr bssid, struct ether_addr smac, struct ether_addr dmac, fuzzing_option *fuzzing_opt)
 {
-	struct ieee_hdr *hdr;
+	struct ieee_hdr *hdr = NULL;
 	struct packet fuzz_pkt = {0};
 	uint8_t frame_type = 0;
 
@@ -861,7 +871,9 @@ void handle_sta_auth(struct packet *pkt, struct ether_addr bssid, struct ether_a
 	frame_type = hdr->type;
 	frame_type = frame_type & 0x0F;
 
-	switch (hdr->type)
+	fuzz_logger_log(FUZZ_LOG_INFO, "[handle_sta_auth] hdr->type: %d (%s)", frame_type, return_frame_name(frame_type));
+
+	switch (frame_type)
 	{
 	case IEEE80211_TYPE_BEACON:
 	{
@@ -920,7 +932,7 @@ void handle_sta_auth(struct packet *pkt, struct ether_addr bssid, struct ether_a
 	case IEEE80211_TYPE_ASSOCREQ:
 	case IEEE80211_TYPE_REASSOCREQ:
 	{
-		if (fuzzing_opt->test_type == TEST_INTERACTIVE)
+		if (TEST_INTERACTIVE == fuzzing_opt->test_type)
 		{
 			print_interaction_status(bssid, smac, dmac, "Association Request", "Association Response");
 
@@ -934,8 +946,13 @@ void handle_sta_auth(struct packet *pkt, struct ether_addr bssid, struct ether_a
 			fuzzing_opt->wpa_s = WPA_ASSOCIATED;
 
 			// 4-way-handshake m1
-			if (fuzzing_opt->auth_type == WPA3 || fuzzing_opt->auth_type == WPA2_PSK_TKIP_AES || fuzzing_opt->auth_type == WPA2_PSK_AES || fuzzing_opt->auth_type == WPA2_PSK_TKIP ||
-				fuzzing_opt->auth_type == WPA_PSK_TKIP_AES || fuzzing_opt->auth_type == WPA_PSK_AES || fuzzing_opt->auth_type == WPA_PSK_TKIP)
+			if (fuzzing_opt->auth_type == WPA3 ||
+				fuzzing_opt->auth_type == WPA2_PSK_TKIP_AES ||
+				fuzzing_opt->auth_type == WPA2_PSK_AES ||
+				fuzzing_opt->auth_type == WPA2_PSK_TKIP ||
+				fuzzing_opt->auth_type == WPA_PSK_TKIP_AES ||
+				fuzzing_opt->auth_type == WPA_PSK_AES ||
+				fuzzing_opt->auth_type == WPA_PSK_TKIP)
 			{
 				fuzzing_opt->wpa_s = WPA_4WAY_HANDSHAKE;
 				fuzz_pkt = get_frame(IEEE80211_TYPE_QOSDATA, bssid, dmac, smac, pkt);
@@ -1031,31 +1048,38 @@ void handle_sta_auth(struct packet *pkt, struct ether_addr bssid, struct ether_a
 // ap, p2p,
 void handle_ap_auth(struct packet *pkt, struct ether_addr bssid, struct ether_addr smac, struct ether_addr dmac, fuzzing_option *fuzzing_opt)
 {
-	struct ieee_hdr *hdr;
+	struct ieee_hdr *hdr = NULL;
 	struct packet fuzz_pkt = {0};
 	uint8_t frame_type = 0;
 
 	hdr = (struct ieee_hdr *)pkt->data;
+
 	frame_type = hdr->type;
 	frame_type = frame_type & 0x0F;
 
-	if (pkt)
+	if (NULL != pkt)
 	{
 		fuzz_pkt.channel = pkt->channel;
 	}
 
+	// fuzz_logger_log(FUZZ_LOG_INFO, "\n[%s:%d] fuzzing_opt->test_type: %d (%s), fuzzing_opt->wpa_s: %d (%s)",
+	// 				__FILE__, __LINE__,
+	// 				fuzzing_opt->test_type, TEST_TYPE_NAME[fuzzing_opt->test_type],
+	// 				fuzzing_opt->wpa_s, wpa_state_names[fuzzing_opt->wpa_s]);
 	if (FUZZ_WORK_MODE_STA == fuzzing_opt->fuzz_work_mode)
 	{
+		// fuzz_logger_log(FUZZ_LOG_INFO, "[%s:%d] hdr->type: %d (%s)", __FILE__, __LINE__, hdr->type, return_frame_name(hdr->type));
 		switch (hdr->type)
 		{
 		case IEEE80211_TYPE_BEACON:
 			if (is_p2p_beacon(pkt))
 			{
+				// fuzz_logger_log(FUZZ_LOG_INFO, "[%s:%d] handle_p2p", __FILE__, __LINE__);
 				handle_p2p(pkt, bssid, smac, dmac, fuzzing_opt);
 			}
 			else
 			{
-				if (fuzzing_opt->test_type == TEST_INTERACTIVE)
+				if (TEST_INTERACTIVE == fuzzing_opt->test_type)
 				{
 					if (fuzzing_opt->wpa_s < WPA_SCANNING)
 					{
@@ -1958,9 +1982,9 @@ void *start_fuzzing(void *param)
 		}*/
 
 		pkt = read_packet_ex();
+		// printf("pkt.len = %d      \r", pkt.len);
 		if (0 == pkt.len)
 		{
-			printf("pkt.len == 0\r");
 			if (FUZZ_WORK_MODE_MITM != fuzzing_opt->fuzz_work_mode)
 			{
 				// fuzz_logger_log(FUZZ_LOG_INFO, "fuzzing_opt->sniff_frames: %d", fuzzing_opt->sniff_frames);
@@ -2141,7 +2165,7 @@ void *start_fuzzing(void *param)
 		}
 
 		frame_name = return_frame_name(hdr->type);
-		fuzz_logger_log(FUZZ_LOG_DEBUG, "recv-->%s", frame_name);
+		// fuzz_logger_log(FUZZ_LOG_INFO, "recv-->%s", frame_name);
 
 		if (FUZZ_WORK_MODE_MITM != fuzzing_opt->fuzz_work_mode)
 		{
@@ -2211,21 +2235,6 @@ void *start_fuzzing(void *param)
 			pass_time2 = current_time2;
 		}
 
-		// fuzz_logger_log(FUZZ_LOG_INFO,
-		// 				"SMAC %02X:%02X:%02X:%02X:%02X:%02X, DMAC %02X:%02X:%02X:%02X:%02X:%02X",
-		// 				smac.ether_addr_octet[0],
-		// 				smac.ether_addr_octet[1],
-		// 				smac.ether_addr_octet[2],
-		// 				smac.ether_addr_octet[3],
-		// 				smac.ether_addr_octet[4],
-		// 				smac.ether_addr_octet[5],
-		// 				dmac.ether_addr_octet[0],
-		// 				dmac.ether_addr_octet[1],
-		// 				dmac.ether_addr_octet[2],
-		// 				dmac.ether_addr_octet[3],
-		// 				dmac.ether_addr_octet[4],
-		// 				dmac.ether_addr_octet[5]);
-
 		// Skip the irrelevant to make the code more readable (smaller 'if')
 		if (!(
 				FUZZ_WORK_MODE_AWDL == fuzzing_opt->fuzz_work_mode ||
@@ -2235,6 +2244,35 @@ void *start_fuzzing(void *param)
 				0 == memcmp(&smac.ether_addr_octet, &fuzzing_opt->target_addr.ether_addr_octet, 6)))
 		{
 			// If we are not working in AWDL mode and the packet doesn't match filter
+			// printf("Packet is not for us... check configured Target MAC and Source MAC\r");
+			if (0 != memcmp(dmac.ether_addr_octet, BROADCAST, 6))
+			{
+				char smac_address[128] = {0};
+				char dmac_address[128] = {0};
+				sprintf(smac_address, "%02X:%02X:%02X:%02X:%02X:%02X", smac.ether_addr_octet[0], smac.ether_addr_octet[1],
+						smac.ether_addr_octet[2], smac.ether_addr_octet[3],
+						smac.ether_addr_octet[4], smac.ether_addr_octet[5]);
+
+				sprintf(dmac_address, "%02X:%02X:%02X:%02X:%02X:%02X", dmac.ether_addr_octet[0], dmac.ether_addr_octet[1],
+						dmac.ether_addr_octet[2], dmac.ether_addr_octet[3],
+						dmac.ether_addr_octet[4], dmac.ether_addr_octet[5]);
+
+				if (NULL == ht_search(ht_notification_hash, smac_address) || NULL == ht_search(ht_notification_hash, dmac_address))
+				{
+					create_item(ht_)
+					fuzz_logger_log(FUZZ_LOG_INFO,
+									"Packet is not for us.. smac %s, dmac %s"
+									"\nMake packets for us.. target %02X:%02X:%02X:%02X:%02X:%02X, source %02X:%02X:%02X:%02X:%02X:%02X",
+									smac_address,
+									dmac_address,
+									fuzzing_opt->target_addr.ether_addr_octet[0], fuzzing_opt->target_addr.ether_addr_octet[1],
+									fuzzing_opt->target_addr.ether_addr_octet[2], fuzzing_opt->target_addr.ether_addr_octet[3],
+									fuzzing_opt->target_addr.ether_addr_octet[4], fuzzing_opt->target_addr.ether_addr_octet[5],
+									fuzzing_opt->source_addr.ether_addr_octet[0], fuzzing_opt->source_addr.ether_addr_octet[1],
+									fuzzing_opt->source_addr.ether_addr_octet[2], fuzzing_opt->source_addr.ether_addr_octet[3],
+									fuzzing_opt->source_addr.ether_addr_octet[4], fuzzing_opt->source_addr.ether_addr_octet[5]);
+				}
+			}
 			continue;
 		}
 
@@ -2259,7 +2297,7 @@ void *start_fuzzing(void *param)
 			fuzzing_opt->target_alive = 1;
 		}
 
-		if (fuzzing_opt->sniff_frames == 1 /*FUZZ_WORK_MODE_AP == fuzzing_opt->fuzz_work_mode || FUZZ_WORK_MODE_STA == fuzzing_opt->fuzz_work_mode*/)
+		if (1 == fuzzing_opt->sniff_frames /*FUZZ_WORK_MODE_AP == fuzzing_opt->fuzz_work_mode || FUZZ_WORK_MODE_STA == fuzzing_opt->fuzz_work_mode*/)
 		{
 			if (TEST_FRAME == fuzzing_opt->test_type)
 			{
@@ -2267,7 +2305,7 @@ void *start_fuzzing(void *param)
 
 				// fuzz_logger_log(FUZZ_LOG_INFO, "fuzzing_opt->cur_sfs_cnt: %d", fuzzing_opt->cur_sfs_cnt);
 
-				if (fuzzing_opt->cur_sfs_cnt >= 3) // beacon, probe_request, probe_response, assoc_req, assoc_res, action, ...
+				if (fuzzing_opt->cur_sfs_cnt >= CAPTURED_PKT_BEFORE_FUZZING) // beacon, probe_request, probe_response, assoc_req, assoc_res, action, ...
 				{
 					fuzzing_opt->sniff_frames = 0;
 
@@ -2277,7 +2315,7 @@ void *start_fuzzing(void *param)
 				else
 				{
 					// We don't use fuzz_logger_log because we want it to stay on the same line
-					printf("Need more packets...\r");
+					printf("Need more packets... have: %d, need: %d\r", fuzzing_opt->cur_sfs_cnt, CAPTURED_PKT_BEFORE_FUZZING);
 				}
 			}
 		}
@@ -2287,11 +2325,13 @@ void *start_fuzzing(void *param)
 			handle_mesh(&pkt, bssid, smac, dmac, tmac, fuzzing_opt);
 		}
 
-		if ((memcmp(&dmac.ether_addr_octet, &fuzzing_opt->target_addr.ether_addr_octet, 6) == 0 &&
-			 memcmp(&smac.ether_addr_octet, &fuzzing_opt->source_addr.ether_addr_octet, 6) == 0) ||
-			(memcmp(&dmac.ether_addr_octet, &fuzzing_opt->source_addr.ether_addr_octet, 6) == 0 &&
-			 memcmp(&smac.ether_addr_octet, &fuzzing_opt->target_addr.ether_addr_octet, 6) == 0))
+		// If the packet is for us, check that the device is still alive
+		if ((0 == memcmp(&dmac.ether_addr_octet, &fuzzing_opt->target_addr.ether_addr_octet, 6) &&
+			 0 == memcmp(&smac.ether_addr_octet, &fuzzing_opt->source_addr.ether_addr_octet, 6)) ||
+			(0 == memcmp(&dmac.ether_addr_octet, &fuzzing_opt->source_addr.ether_addr_octet, 6) &&
+			 0 == memcmp(&smac.ether_addr_octet, &fuzzing_opt->target_addr.ether_addr_octet, 6)))
 		{
+			// fuzz_logger_log(FUZZ_LOG_INFO, "[%s:%d] Packet is for us", __FILE__, __LINE__);
 			if (0 == fuzzing_opt->sniff_frames)
 			{
 				if (!check_alive_by_deauth(&pkt))
@@ -2358,6 +2398,32 @@ void *start_fuzzing(void *param)
 				if (is_awdl_frame(&pkt))
 					handle_awdl(&pkt, bssid, smac, dmac, fuzzing_opt);
 			}
+			else
+			{
+				if (0 != memcmp(dmac.ether_addr_octet, BROADCAST, 6))
+				{
+					// Skip those that are broadcast, they are not relevant for us
+					// Notify user if the settings don't match..
+					fuzz_logger_log(FUZZ_LOG_INFO,
+									"[%s:%d] Packet, frame_name: '%s', is not for us.. smac %02X:%02X:%02X:%02X:%02X:%02X, dmac %02X:%02X:%02X:%02X:%02X:%02X"
+									"\n[%s:%d] Make packets for us.. target %02X:%02X:%02X:%02X:%02X:%02X, source %02X:%02X:%02X:%02X:%02X:%02X",
+									__FILE__, __LINE__,
+									frame_name,
+									smac.ether_addr_octet[0], smac.ether_addr_octet[1],
+									smac.ether_addr_octet[2], smac.ether_addr_octet[3],
+									smac.ether_addr_octet[4], smac.ether_addr_octet[5],
+									dmac.ether_addr_octet[0], dmac.ether_addr_octet[1],
+									dmac.ether_addr_octet[2], dmac.ether_addr_octet[3],
+									dmac.ether_addr_octet[4], dmac.ether_addr_octet[5],
+									__FILE__, __LINE__,
+									fuzzing_opt->target_addr.ether_addr_octet[0], fuzzing_opt->target_addr.ether_addr_octet[1],
+									fuzzing_opt->target_addr.ether_addr_octet[2], fuzzing_opt->target_addr.ether_addr_octet[3],
+									fuzzing_opt->target_addr.ether_addr_octet[4], fuzzing_opt->target_addr.ether_addr_octet[5],
+									fuzzing_opt->source_addr.ether_addr_octet[0], fuzzing_opt->source_addr.ether_addr_octet[1],
+									fuzzing_opt->source_addr.ether_addr_octet[2], fuzzing_opt->source_addr.ether_addr_octet[3],
+									fuzzing_opt->source_addr.ether_addr_octet[4], fuzzing_opt->source_addr.ether_addr_octet[5]);
+				}
+			}
 		}
 
 		if (0 == memcmp(&smac.ether_addr_octet, &fuzzing_opt->source_addr.ether_addr_octet, 6) &&
@@ -2365,6 +2431,7 @@ void *start_fuzzing(void *param)
 		)
 		{
 			seq_ctrl = get_seqno(&pkt);
+			fuzz_logger_log(FUZZ_LOG_INFO, "[%s:%d] seq_ctrl: %d", __FILE__, __LINE__, seq_ctrl);
 			if (MANAGMENT_FRAME == (hdr->type & 0x0F))
 			{
 				if (seq_ctrl != fuzzing_opt->seq_ctrl)
@@ -2372,7 +2439,7 @@ void *start_fuzzing(void *param)
 					fuzzing_opt->seq_ctrl = seq_ctrl;
 					set_seqno(NULL, seq_ctrl);
 
-					fuzz_logger_log(FUZZ_LOG_DEBUG, "source management frame seq = %d", fuzzing_opt->seq_ctrl);
+					fuzz_logger_log(FUZZ_LOG_DEBUG, "Source management frame seq = %d", fuzzing_opt->seq_ctrl);
 				}
 			}
 			else if (DATA_FRAME == (hdr->type & 0x0F))
@@ -2382,7 +2449,7 @@ void *start_fuzzing(void *param)
 					fuzzing_opt->data_seq_ctrl = seq_ctrl;
 					// set_data_seqno(NULL, data_seq_ctrl);
 
-					fuzz_logger_log(FUZZ_LOG_DEBUG, "source data frame seq = %d", fuzzing_opt->data_seq_ctrl);
+					fuzz_logger_log(FUZZ_LOG_DEBUG, "Source data frame seq = %d", fuzzing_opt->data_seq_ctrl);
 				}
 			}
 
@@ -2683,6 +2750,8 @@ int fuzzing(int argc, char *argv[])
 	char *file_log_path = NULL;
 	pthread_t fthread;
 
+	ht_notification_hash = create_table(CAPACITY);
+
 	// Set all the fields of the structure to 0
 	memset(&fuzzing_opt, 0, sizeof(fuzzing_opt));
 
@@ -2831,35 +2900,35 @@ int fuzzing(int argc, char *argv[])
 
 		if (interface == NULL)
 		{
-			fuzz_logger_log(FUZZ_LOG_ERR, "Interface not set!");
+			fuzz_logger_log(FUZZ_LOG_ERR, "Interface has not been set!");
 			usage_help(argv[0]);
 			return -1;
 		}
 
 		if (target_mac_str == NULL)
 		{
-			fuzz_logger_log(FUZZ_LOG_ERR, "no set fuzzing target's MAC.");
+			fuzz_logger_log(FUZZ_LOG_ERR, "Fuzzing target's MAC is missing.");
 			usage_help(argv[0]);
 			return -1;
 		}
 
 		if (source_mac_str == NULL)
 		{
-			fuzz_logger_log(FUZZ_LOG_ERR, "no set fuzzing source MAC address.");
+			fuzz_logger_log(FUZZ_LOG_ERR, "Fuzzing source MAC address is missing.");
 			usage_help(argv[0]);
 			return -1;
 		}
 
 		if (ap_bssid_str == NULL)
 		{
-			fuzz_logger_log(FUZZ_LOG_ERR, "no set bssid.");
+			fuzz_logger_log(FUZZ_LOG_ERR, "BSSID is missing.");
 			usage_help(argv[0]);
 			return -1;
 		}
 
 		if (auth_type == NULL)
 		{
-			fuzz_logger_log(FUZZ_LOG_ERR, "no set fuzzing target's auth type.");
+			fuzz_logger_log(FUZZ_LOG_ERR, "Fuzzing target's auth type is missing.");
 			usage_help(argv[0]);
 			return -1;
 		}
@@ -2997,9 +3066,10 @@ int fuzzing(int argc, char *argv[])
 					fuzzing_opt.bssid.ether_addr_octet[4],
 					fuzzing_opt.bssid.ether_addr_octet[5]);
 
-	fuzz_logger_log(FUZZ_LOG_INFO, "Fuzzing target's SSID: %s", fuzzing_opt.target_ssid);
+	fuzz_logger_log(FUZZ_LOG_INFO, "Fuzzing target's SSID: [%s]", fuzzing_opt.target_ssid);
 	fuzz_logger_log(FUZZ_LOG_INFO, "auth_type: %d (%s)", fuzzing_opt.auth_type, AP_AUTH_TYPE_NAME[fuzzing_opt.auth_type]);
 	fuzz_logger_log(FUZZ_LOG_INFO, "test_type: %d (%s)", fuzzing_opt.test_type, TEST_TYPE_NAME[fuzzing_opt.test_type]);
+	fuzz_logger_log(FUZZ_LOG_INFO, "sniff_frames: %d", fuzzing_opt.sniff_frames);
 
 	if (0 == fuzzing_opt.seed)
 	{
@@ -3053,9 +3123,13 @@ int fuzzing(int argc, char *argv[])
 		}
 	}
 
+	fuzz_logger_log(FUZZ_LOG_INFO, "Calling 'start_fuzzing'\n");
+
 	start_fuzzing(&fuzzing_opt);
 
 	// close_pcap();
+
+	free_table(ht_notification_hash);
 
 	return 0;
 }
@@ -3074,31 +3148,36 @@ void print_status(struct packet *pkt)
 		printf("\tInterface: %s\t\tWorking Channel: %d\n", fuzzing_opt.ois[i].osdep_iface_out, fuzzing_opt.ois[i].channel);
 	}
 
-	printf("\tTarget MAC: %02X:%02X:%02X:%02X:%02X:%02X\t\tFuzzing MAC: %02X:%02X:%02X:%02X:%02X:%02X\n", fuzzing_opt.target_addr.ether_addr_octet[0], fuzzing_opt.target_addr.ether_addr_octet[1],
+	printf("\tTarget MAC: %02X:%02X:%02X:%02X:%02X:%02X\t\tFuzzing MAC: %02X:%02X:%02X:%02X:%02X:%02X\n",
+		   fuzzing_opt.target_addr.ether_addr_octet[0], fuzzing_opt.target_addr.ether_addr_octet[1],
 		   fuzzing_opt.target_addr.ether_addr_octet[2], fuzzing_opt.target_addr.ether_addr_octet[3], fuzzing_opt.target_addr.ether_addr_octet[4], fuzzing_opt.target_addr.ether_addr_octet[5],
 		   fuzzing_opt.source_addr.ether_addr_octet[0], fuzzing_opt.source_addr.ether_addr_octet[1],
 		   fuzzing_opt.source_addr.ether_addr_octet[2], fuzzing_opt.source_addr.ether_addr_octet[3], fuzzing_opt.source_addr.ether_addr_octet[4], fuzzing_opt.source_addr.ether_addr_octet[5]);
-	printf("\tBSSID: %02X:%02X:%02X:%02X:%02X:%02X\t\tFuzzing Mode: %s\n", fuzzing_opt.bssid.ether_addr_octet[0], fuzzing_opt.bssid.ether_addr_octet[1],
+	printf("\tBSSID: %02X:%02X:%02X:%02X:%02X:%02X\t\tFuzzing Mode: %s\n",
+		   fuzzing_opt.bssid.ether_addr_octet[0], fuzzing_opt.bssid.ether_addr_octet[1],
 		   fuzzing_opt.bssid.ether_addr_octet[2], fuzzing_opt.bssid.ether_addr_octet[3], fuzzing_opt.bssid.ether_addr_octet[4], fuzzing_opt.bssid.ether_addr_octet[5], fuzzing_opt.mode);
 
-	if ((fuzzing_opt.fuzz_work_mode == FUZZ_WORK_MODE_P2P) && fuzzing_opt.p2p_frame_test)
+	if ((FUZZ_WORK_MODE_P2P == fuzzing_opt.fuzz_work_mode) && fuzzing_opt.p2p_frame_test)
 	{
 		// p2p
-		printf("\t*p2p_target_addr: %02X:%02X:%02X:%02X:%02X:%02X\n", fuzzing_opt.p2p_target_addr.ether_addr_octet[0],
+		printf("\t*p2p_target_addr: %02X:%02X:%02X:%02X:%02X:%02X\n",
+			   fuzzing_opt.p2p_target_addr.ether_addr_octet[0],
 			   fuzzing_opt.p2p_target_addr.ether_addr_octet[1],
 			   fuzzing_opt.p2p_target_addr.ether_addr_octet[2],
 			   fuzzing_opt.p2p_target_addr.ether_addr_octet[3],
 			   fuzzing_opt.p2p_target_addr.ether_addr_octet[4],
 			   fuzzing_opt.p2p_target_addr.ether_addr_octet[5]);
 
-		printf("\t*p2p_source_addr: %02X:%02X:%02X:%02X:%02X:%02X\n", fuzzing_opt.p2p_source_addr.ether_addr_octet[0],
+		printf("\t*p2p_source_addr: %02X:%02X:%02X:%02X:%02X:%02X\n",
+			   fuzzing_opt.p2p_source_addr.ether_addr_octet[0],
 			   fuzzing_opt.p2p_source_addr.ether_addr_octet[1],
 			   fuzzing_opt.p2p_source_addr.ether_addr_octet[2],
 			   fuzzing_opt.p2p_source_addr.ether_addr_octet[3],
 			   fuzzing_opt.p2p_source_addr.ether_addr_octet[4],
 			   fuzzing_opt.p2p_source_addr.ether_addr_octet[5]);
 
-		printf("\t*p2p_bssid: %02X:%02X:%02X:%02X:%02X:%02X\n", fuzzing_opt.p2p_bssid.ether_addr_octet[0],
+		printf("\t*p2p_bssid: %02X:%02X:%02X:%02X:%02X:%02X\n",
+			   fuzzing_opt.p2p_bssid.ether_addr_octet[0],
 			   fuzzing_opt.p2p_bssid.ether_addr_octet[1],
 			   fuzzing_opt.p2p_bssid.ether_addr_octet[2],
 			   fuzzing_opt.p2p_bssid.ether_addr_octet[3],
@@ -3108,17 +3187,17 @@ void print_status(struct packet *pkt)
 		printf("\t*p2p_operating_interface_id: %d\n", fuzzing_opt.p2p_operating_interface_id);
 	}
 
-	if (fuzzing_opt.test_type == TEST_INTERACTIVE)
+	if (TEST_INTERACTIVE == fuzzing_opt.test_type)
 	{
 		printf("\tFuzzing Type: %d (Interactive)\n", fuzzing_opt.test_type);
 	}
-	else if (fuzzing_opt.test_type == TEST_FRAME)
+	else if (TEST_FRAME == fuzzing_opt.test_type)
 	{
-		if (fuzzing_opt.fuzz_work_mode == FUZZ_WORK_MODE_AP || fuzzing_opt.fuzz_work_mode == FUZZ_WORK_MODE_STA)
+		if (FUZZ_WORK_MODE_AP == fuzzing_opt.fuzz_work_mode || FUZZ_WORK_MODE_STA == fuzzing_opt.fuzz_work_mode)
 		{
 			printf("\tFuzzing Type: %d (Frame testing)\t\tFrame types: %d\n", fuzzing_opt.test_type, fuzzing_opt.owfuzz_frames_cnt);
 		}
-		else if (fuzzing_opt.fuzz_work_mode == FUZZ_WORK_MODE_P2P)
+		else if (FUZZ_WORK_MODE_P2P == fuzzing_opt.fuzz_work_mode)
 		{
 			printf("\tFuzzing Type: %d (p2p frame testing)\t\tFrame types: %d\n", fuzzing_opt.test_type, sizeof(p2p_frames) / sizeof(p2p_frames[0]));
 		}
@@ -3126,7 +3205,7 @@ void print_status(struct packet *pkt)
 
 	printf("\tAP SSID: %s\t\t\t", fuzzing_opt.target_ssid);
 
-	if (strlen(fuzzing_opt.target_ip))
+	if (strlen(fuzzing_opt.target_ip) > 0)
 	{
 		printf("\tTarget IP: %s\n", fuzzing_opt.target_ip);
 	}
@@ -3135,10 +3214,12 @@ void print_status(struct packet *pkt)
 		printf("\n");
 	}
 
-	printf("\tCurrent Frame: %02X\t\t\tCurrent IE: %d\t\tCurrent IE EXT: %d\n\tFuzzing Step: %d\t\t\t\tFuzzing Value Step: %d\n", fuzzing_opt.current_frame,
+	printf("\tCurrent Frame: %02X\t\t\tCurrent IE: %d\t\tCurrent IE EXT: %d\n\tFuzzing Step: %d\t\t\t\tFuzzing Value Step: %d\n",
+		   fuzzing_opt.current_frame,
 		   fuzzing_opt.current_ie, fuzzing_opt.current_ie_ext, fuzzing_opt.fuzzing_step, fuzzing_opt.fuzzing_value_step);
 
-	printf("\tFuzzing Frame Count: %u\t\t\tPoC Count: \033[22;31m%u\033[22;39m\n", fuzzing_opt.fuzz_pkt_num, fuzzing_opt.fuzz_exp_pkt_cnt);
+	printf("\tFuzzing Frame Count: %u\t\t\tPoC Count: \033[22;31m%u\033[22;39m\n",
+		   fuzzing_opt.fuzz_pkt_num, fuzzing_opt.fuzz_exp_pkt_cnt);
 
 	if (NULL != pkt)
 	{

--- a/owfuzz/src/fuzz_control.c
+++ b/owfuzz/src/fuzz_control.c
@@ -190,11 +190,23 @@ void *test_bad_frame(void *param)
 	uint8_t dsflags;
 	struct beacon_fixed *bf;
 	static uint64_t internal_timestamp = 0;
+	int bad_frame_packets = 0;
 
 	bad_frame = (struct packet *)malloc(sizeof(struct packet) * MAX_BAD_FRAME_COUNT);
 	memset(bad_frame, 0, sizeof(struct packet) * MAX_BAD_FRAME_COUNT);
 
 	load_payloads();
+
+	for (i = 0; i < MAX_BAD_FRAME_COUNT; i++)
+	{
+		if (bad_frame[i].len != 0)
+			bad_frame_packets++;
+	}
+
+	if (0 == bad_frame_packets) {
+		fuzz_logger_log(FUZZ_LOG_ERR, "No bad frame packets defined, exiting");
+		exit(-1);
+	}
 
 	sleep(2);
 

--- a/owfuzz/src/fuzz_control.c
+++ b/owfuzz/src/fuzz_control.c
@@ -2165,6 +2165,7 @@ void *start_fuzzing(void *param)
 		}
 
 		frame_name = return_frame_name(hdr->type);
+		// printf("[%s:%d] fuzz_pkt_num: %d                 \r", __FILE__, __LINE__, fuzzing_opt->fuzz_pkt_num);
 		// fuzz_logger_log(FUZZ_LOG_INFO, "recv-->%s", frame_name);
 
 		if (FUZZ_WORK_MODE_MITM != fuzzing_opt->fuzz_work_mode)
@@ -2446,7 +2447,7 @@ void *start_fuzzing(void *param)
 		)
 		{
 			seq_ctrl = get_seqno(&pkt);
-			fuzz_logger_log(FUZZ_LOG_INFO, "[%s:%d] seq_ctrl: %d", __FILE__, __LINE__, seq_ctrl);
+			// fuzz_logger_log(FUZZ_LOG_INFO, "[%s:%d] seq_ctrl: %d", __FILE__, __LINE__, seq_ctrl);
 			if (MANAGMENT_FRAME == (hdr->type & 0x0F))
 			{
 				if (seq_ctrl != fuzzing_opt->seq_ctrl)
@@ -2499,13 +2500,15 @@ void *start_fuzzing(void *param)
 
 		if (
 			0 == memcmp(&smac.ether_addr_octet, &fuzzing_opt->target_addr.ether_addr_octet, 6) &&
-			(memcmp(&dmac.ether_addr_octet, &fuzzing_opt->source_addr.ether_addr_octet, 6) == 0 ||
-			 (dmac.ether_addr_octet[0] == 0xff &&
-			  dmac.ether_addr_octet[1] == 0xff &&
-			  dmac.ether_addr_octet[2] == 0xff &&
-			  dmac.ether_addr_octet[3] == 0xff &&
-			  dmac.ether_addr_octet[4] == 0xff &&
-			  dmac.ether_addr_octet[5] == 0xff)))
+			(0 == memcmp(&dmac.ether_addr_octet, &fuzzing_opt->source_addr.ether_addr_octet, 6) ||
+			 0 == memcmp(dmac.ether_addr_octet, BROADCAST, 6)
+			 //  (dmac.ether_addr_octet[0] == 0xff &&
+			 //   dmac.ether_addr_octet[1] == 0xff &&
+			 //   dmac.ether_addr_octet[2] == 0xff &&
+			 //   dmac.ether_addr_octet[3] == 0xff &&
+			 //   dmac.ether_addr_octet[4] == 0xff &&
+			 //   dmac.ether_addr_octet[5] == 0xff)
+			 ))
 		{
 			recv_seq_ctrl = get_seqno(&pkt);
 			if (MANAGMENT_FRAME == (hdr->type & 0x0F))
@@ -2516,7 +2519,7 @@ void *start_fuzzing(void *param)
 					fuzzing_opt->recv_seq_ctrl = recv_seq_ctrl;
 				}
 			}
-			else if ((hdr->type & 0x0F) == DATA_FRAME)
+			else if (DATA_FRAME == (hdr->type & 0x0F))
 			{
 				// target's packet data seq number
 				if (recv_seq_ctrl != fuzzing_opt->recv_data_seq_ctrl)
@@ -2527,7 +2530,7 @@ void *start_fuzzing(void *param)
 
 			fuzzing_opt->target_alive = 1;
 
-			if (fuzzing_opt->test_type == TEST_INTERACTIVE)
+			if (TEST_INTERACTIVE == fuzzing_opt->test_type)
 			{
 				if (FUZZ_WORK_MODE_AP == fuzzing_opt->fuzz_work_mode)
 				{

--- a/owfuzz/src/fuzz_control.c
+++ b/owfuzz/src/fuzz_control.c
@@ -2245,7 +2245,23 @@ void *start_fuzzing(void *param)
 		{
 			// If we are not working in AWDL mode and the packet doesn't match filter
 			// printf("Packet is not for us... check configured Target MAC and Source MAC\r");
-			if (0 != memcmp(dmac.ether_addr_octet, BROADCAST, 6))
+			if (0 != memcmp(bssid.ether_addr_octet, fuzzing_opt->bssid.ether_addr_octet, 6))
+			{
+				char bssid_address[128] = {0};
+				sprintf(bssid_address, "%02X:%02X:%02X:%02X:%02X:%02X", bssid.ether_addr_octet[0], bssid.ether_addr_octet[1],
+						bssid.ether_addr_octet[2], bssid.ether_addr_octet[3],
+						bssid.ether_addr_octet[4], bssid.ether_addr_octet[5]);
+
+				if (NULL == ht_search(ht_notification_hash, bssid_address))
+				{
+					ht_insert(ht_notification_hash, bssid_address, "notified");
+					fuzz_logger_log(FUZZ_LOG_INFO,
+									"[%s:%d] BSSID mismatch: %s",
+									__FILE__, __LINE__,
+									bssid_address);
+				}
+			}
+			if (0 != memcmp(dmac.ether_addr_octet, BROADCAST, 6) && 0 == memcmp(bssid.ether_addr_octet, fuzzing_opt->bssid.ether_addr_octet, 6))
 			{
 				char smac_address[128] = {0};
 				char dmac_address[128] = {0};
@@ -2395,7 +2411,7 @@ void *start_fuzzing(void *param)
 			}
 			else
 			{
-				if (0 != memcmp(dmac.ether_addr_octet, BROADCAST, 6))
+				if (0 != memcmp(dmac.ether_addr_octet, BROADCAST, 6) && 0 == memcmp(bssid.ether_addr_octet, fuzzing_opt->bssid.ether_addr_octet, 6))
 				{
 					// Skip those that are broadcast, they are not relevant for us
 					// Notify user if the settings don't match..

--- a/owfuzz/src/hashtable.c
+++ b/owfuzz/src/hashtable.c
@@ -1,0 +1,139 @@
+// https://www.digitalocean.com/community/tutorials/hash-table-in-c-plus-plus
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "hashtable.h"
+
+unsigned long hash_function(char *str)
+{
+    unsigned long i = 0;
+
+    for (int j = 0; str[j]; j++)
+        i += str[j];
+
+    return i % CAPACITY;
+}
+
+void ht_insert(HashTable *table, char *key, char *value)
+{
+    // Creates the item.
+    Ht_item *item = create_item(key, value);
+
+    // Computes the index.
+    int index = hash_function(key);
+
+    Ht_item *current_item = table->items[index];
+
+    if (current_item == NULL)
+    {
+        // Key does not exist.
+        if (table->count == table->size)
+        {
+            // HashTable is full.
+            printf("Insert Error: Hash Table is full\n");
+            free_item(item);
+            return;
+        }
+
+        // Insert directly.
+        table->items[index] = item;
+        table->count++;
+    }
+    else
+    {
+        // Scenario 1: Update the value.
+        if (strcmp(current_item->key, key) == 0)
+        {
+            strcpy(table->items[index]->value, value);
+            return;
+        }
+        else
+        {
+            // Scenario 2: Handle the collision.
+            // handle_collision(table, index, item);
+            return;
+        }
+    }
+}
+
+
+Ht_item *create_item(char *key, char *value)
+{
+    // Creates a pointer to a new HashTable item.
+    Ht_item *item = (Ht_item *)malloc(sizeof(Ht_item));
+    item->key = (char *)malloc(strlen(key) + 1);
+    item->value = (char *)malloc(strlen(value) + 1);
+    strcpy(item->key, key);
+    strcpy(item->value, value);
+    return item;
+}
+
+HashTable *create_table(int size)
+{
+    // Creates a new HashTable.
+    HashTable *table = (HashTable *)malloc(sizeof(HashTable));
+    table->size = size;
+    table->count = 0;
+    table->items = (Ht_item **)calloc(table->size, sizeof(Ht_item *));
+
+    for (int i = 0; i < table->size; i++)
+        table->items[i] = NULL;
+
+    return table;
+}
+
+void free_item(Ht_item* item)
+{
+    // Frees an item.
+    free(item->key);
+    free(item->value);
+    free(item);
+}
+
+void free_table(HashTable* table)
+{
+    // Frees the table.
+    for (int i = 0; i < table->size; i++)
+    {
+        Ht_item* item = table->items[i];
+
+        if (item != NULL)
+            free_item(item);
+    }
+
+    free(table->items);
+    free(table);
+}
+
+void print_table(HashTable* table)
+{
+    printf("\nHash Table\n-------------------\n");
+
+    for (int i = 0; i < table->size; i++)
+    {
+        if (table->items[i])
+        {
+            printf("Index:%d, Key:%s, Value:%s\n", i, table->items[i] -> key, table->items[i]->value);
+        }
+    }
+
+    printf("-------------------\n\n");
+}
+
+char* ht_search(HashTable* table, char* key)
+{
+    // Searches for the key in the HashTable.
+    // Returns NULL if it doesn't exist.
+    int index = hash_function(key);
+    Ht_item* item = table->items[index];
+
+    // Provide only non-NULL values.
+    if (item != NULL)
+    {
+        if (strcmp(item->key, key) == 0)
+            return item->value;
+    }
+
+    return NULL;
+}

--- a/owfuzz/src/hashtable.h
+++ b/owfuzz/src/hashtable.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#define CAPACITY 50000 // Size of the HashTable.
+
+// Defines the HashTable item.
+typedef struct Ht_item
+{
+    char *key;
+    char *value;
+} Ht_item;
+
+// Defines the HashTable.
+typedef struct HashTable
+{
+    // Contains an array of pointers to items.
+    Ht_item **items;
+    int size;
+    int count;
+} HashTable;
+
+unsigned long hash_function(char *str);
+Ht_item *create_item(char *key, char *value);
+HashTable *create_table(int size);
+void free_item(Ht_item* item);
+void free_table(HashTable* table);
+void print_table(HashTable* table);
+char* ht_search(HashTable* table, char* key);
+void ht_insert(HashTable *table, char *key, char *value);

--- a/owfuzz/src/tests/Makefile
+++ b/owfuzz/src/tests/Makefile
@@ -2,7 +2,7 @@ RELATIVE_PATH = ../../
 
 NETLINKLIBS = -lnl-genl-3 -lnl-3
 
-OBJS = test_wi_read test_wi_write
+OBJS = test_wi_read test_wi_write test_wi_threads
 
 all: $(OBJS)
 
@@ -35,6 +35,22 @@ test_wi_write: test_wi_write.c
 		$(RELATIVE_PATH)linux_wifi/trans/osdep/linux.o \
 		$(RELATIVE_PATH)linux_wifi/trans/osdep/file.o \
 		-o test_wi_write \
+		-lm \
+		$(NETLINKLIBS)
+
+test_wi_threads: test_wi_threads.c
+	gcc -g test_wi_threads.c \
+		-I/usr/include/unicode/ \
+		-I$(RELATIVE_PATH)linux_wifi/trans/ \
+		$(RELATIVE_PATH)linux_wifi/trans/osdep/osdep.o \
+		$(RELATIVE_PATH)linux_wifi/trans/osdep/network.o \
+		$(RELATIVE_PATH)linux_wifi/control/wifi_ht_channels.o \
+		$(RELATIVE_PATH)linux_wifi/control/capture_linux_wifi/linux_netlink_control.o \
+		$(RELATIVE_PATH)linux_wifi/trans/osdep/common.o \
+		$(RELATIVE_PATH)linux_wifi/trans/osdep/radiotap/radiotap.o \
+		$(RELATIVE_PATH)linux_wifi/trans/osdep/linux.o \
+		$(RELATIVE_PATH)linux_wifi/trans/osdep/file.o \
+		-o test_wi_threads \
 		-lm \
 		$(NETLINKLIBS)
 

--- a/owfuzz/src/tests/Makefile
+++ b/owfuzz/src/tests/Makefile
@@ -2,8 +2,29 @@ RELATIVE_PATH = ../../
 
 NETLINKLIBS = -lnl-genl-3 -lnl-3
 
+OBJS = test_wi_read test_wi_write
+
+all: $(OBJS)
+
+test_wi_read: test_wi_read.c
+	gcc -g test_wi_read.c \
+		-I/usr/include/unicode/ \
+		-I$(RELATIVE_PATH)linux_wifi/trans/ \
+		$(RELATIVE_PATH)linux_wifi/trans/osdep/osdep.o \
+		$(RELATIVE_PATH)linux_wifi/trans/osdep/network.o \
+		$(RELATIVE_PATH)linux_wifi/control/wifi_ht_channels.o \
+		$(RELATIVE_PATH)linux_wifi/control/capture_linux_wifi/linux_netlink_control.o \
+		$(RELATIVE_PATH)linux_wifi/trans/osdep/common.o \
+		$(RELATIVE_PATH)linux_wifi/trans/osdep/radiotap/radiotap.o \
+		$(RELATIVE_PATH)linux_wifi/trans/osdep/linux.o \
+		$(RELATIVE_PATH)linux_wifi/trans/osdep/file.o \
+		-o test_wi_read \
+		-lm \
+		$(NETLINKLIBS)
+
 test_wi_write: test_wi_write.c
-	gcc test_wi_write.c \
+	gcc -g test_wi_write.c \
+		-I/usr/include/unicode/ \
 		-I$(RELATIVE_PATH)linux_wifi/trans/ \
 		$(RELATIVE_PATH)linux_wifi/trans/osdep/osdep.o \
 		$(RELATIVE_PATH)linux_wifi/trans/osdep/network.o \
@@ -17,4 +38,5 @@ test_wi_write: test_wi_write.c
 		-lm \
 		$(NETLINKLIBS)
 
-all: test_wi_write
+clean:
+	rm $(OBJS)

--- a/owfuzz/src/tests/Makefile
+++ b/owfuzz/src/tests/Makefile
@@ -1,0 +1,20 @@
+RELATIVE_PATH = ../../
+
+NETLINKLIBS = -lnl-genl-3 -lnl-3
+
+test_wi_write: test_wi_write.c
+	gcc test_wi_write.c \
+		-I$(RELATIVE_PATH)linux_wifi/trans/ \
+		$(RELATIVE_PATH)linux_wifi/trans/osdep/osdep.o \
+		$(RELATIVE_PATH)linux_wifi/trans/osdep/network.o \
+		$(RELATIVE_PATH)linux_wifi/control/wifi_ht_channels.o \
+		$(RELATIVE_PATH)linux_wifi/control/capture_linux_wifi/linux_netlink_control.o \
+		$(RELATIVE_PATH)linux_wifi/trans/osdep/common.o \
+		$(RELATIVE_PATH)linux_wifi/trans/osdep/radiotap/radiotap.o \
+		$(RELATIVE_PATH)linux_wifi/trans/osdep/linux.o \
+		$(RELATIVE_PATH)linux_wifi/trans/osdep/file.o \
+		-o test_wi_write \
+		-lm \
+		$(NETLINKLIBS)
+
+all: test_wi_write

--- a/owfuzz/src/tests/test_wi_read.c
+++ b/owfuzz/src/tests/test_wi_read.c
@@ -25,9 +25,23 @@ void test_single_wi_read(char *iface)
     dev.fd_out = wi_fd(wi);
     printf("wi_fd successful: %d\n", dev.fd_out);
 
-    int res = wi_read(wi, pkt.data, MAX_IEEE_PACKET_SIZE, &pkt.ri);
-    assert(res != -1 && "Failed to wi_read");
-    printf("wi_read successful: %d\n", res);
+    int rc = 0;
+    do
+	{
+		rc = wi_read(wi, pkt.data, MAX_IEEE_PACKET_SIZE, &pkt.ri);
+        printf("rc: %d      \r", rc);
+		if (-1 == rc)
+		{
+			assert(0 && "wi_read()");
+			pkt.len = 0;
+            break;
+		}
+        sleep(0.1);
+	} while (rc < 1);
+
+	pkt.len = rc;
+	pkt.channel = 7;
+    printf("wi_read successful: %d\n", rc);
 
     wi_close(wi);
     printf("wi_close successful\n");

--- a/owfuzz/src/tests/test_wi_read.c
+++ b/owfuzz/src/tests/test_wi_read.c
@@ -1,0 +1,50 @@
+#include <utypes.h>
+#include <string.h>
+#include <assert.h>
+#include <stdio.h>
+
+#include "osdep_wifi_transmit.h"
+
+#ifdef DEBUG
+Stop
+#endif
+
+void test_single_wi_read(char *iface)
+{
+    struct packet pkt;
+    memset(&pkt, 0, sizeof(struct packet));
+
+    struct wif *wi = wi_open(iface);
+    assert (wi != NULL && "Failed to open interface");
+
+    printf("wi_open successfull %08X\n", wi);
+
+    struct devices dev;
+    memset(&dev, 0, sizeof(struct devices));
+
+    dev.fd_out = wi_fd(wi);
+    printf("wi_fd successful: %d\n", dev.fd_out);
+
+    int res = wi_read(wi, pkt.data, MAX_IEEE_PACKET_SIZE, &pkt.ri);
+    assert(res != -1 && "Failed to wi_read");
+    printf("wi_read successful: %d\n", res);
+
+    wi_close(wi);
+    printf("wi_close successful\n");
+}
+
+int main(int argc, char *argv[])
+{
+    char interface_name[128] = {"wlp59s0"};
+    if (argc == 2)
+    {
+        strcpy(interface_name, argv[1]);
+    }
+    else
+    {
+        strcpy(interface_name, "wlp59s0");
+    }
+    printf("Using interface_name: %s\n", interface_name);
+    printf("\nStarting test_single_wi_read\n");
+    test_single_wi_read(interface_name);
+}

--- a/owfuzz/src/tests/test_wi_read.c
+++ b/owfuzz/src/tests/test_wi_read.c
@@ -5,10 +5,6 @@
 
 #include "osdep_wifi_transmit.h"
 
-#ifdef DEBUG
-Stop
-#endif
-
 void test_single_wi_read(char *iface)
 {
     struct packet pkt;
@@ -17,7 +13,7 @@ void test_single_wi_read(char *iface)
     struct wif *wi = wi_open(iface);
     assert (wi != NULL && "Failed to open interface");
 
-    printf("wi_open successfull %08X\n", wi);
+    printf("wi_open successful %08X\n", wi);
 
     struct devices dev;
     memset(&dev, 0, sizeof(struct devices));

--- a/owfuzz/src/tests/test_wi_threads.c
+++ b/owfuzz/src/tests/test_wi_threads.c
@@ -1,0 +1,108 @@
+#include <utypes.h>
+#include <string.h>
+#include <assert.h>
+#include <stdio.h>
+#include <pthread.h>
+
+#include "osdep_wifi_transmit.h"
+
+pthread_mutex_t owq_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+int send_interval = 0;
+int receive_interval = 0;
+
+struct packet read_packet_ex(struct wif *wi)
+{
+	int rc;
+	struct packet pkt = {0};
+
+	do
+	{
+		rc = wi_read(wi, pkt.data, MAX_IEEE_PACKET_SIZE, &pkt.ri);
+		if (-1 == rc)
+		{
+			perror("wi_read()");
+			pkt.len = 0;
+			return pkt;
+		}
+	} while (rc < 1);
+
+	pkt.len = rc;
+
+	return pkt;
+}
+
+void *receive_thread(void *param)
+{
+	struct wif *wi = (struct wif *)param;
+	struct packet pkt = {0};
+
+	while (true)
+	{
+        receive_interval++;
+		memset(&pkt, 0, sizeof(struct packet));
+		pkt = read_packet_ex(wi);
+		if (pkt.len > 0)
+		{
+			pthread_mutex_lock(&owq_mutex);
+            sleep(0.1); // Simulate pushing to the queue
+			pthread_mutex_unlock(&owq_mutex);
+		}
+		usleep(10);
+	}
+
+	pthread_exit(NULL);
+}
+
+void *send_thread(void *param)
+{
+	struct wif *wi = (struct wif *)param;
+	struct packet pkt = {0};
+    strcpy(pkt.data, "HELLO");
+    pkt.len = strlen("HELLO");
+    pkt.channel = 7;
+
+	while (true)
+	{
+        send_interval++;
+		int res = wi_write(wi, pkt.data, pkt.len, NULL);
+        assert(res != -1 && "Failed to wi_write");
+		sleep(0.1);
+	}
+
+	pthread_exit(NULL);
+}
+
+void test_threads(char *iface) {
+    pthread_t fthread_receive;
+    pthread_t fthread_send;
+
+    struct wif *wi = wi_open(iface);
+    assert (wi != NULL && "Failed to open interface");
+
+    printf("wi_open successful %08X\n", wi);
+
+    pthread_create(&fthread_receive, NULL, receive_thread, wi);
+    pthread_create(&fthread_send, NULL, send_thread, wi);
+    
+    while(true) {
+        printf("receive_interval: %d, send_interval: %d     \r", receive_interval, send_interval);
+        sleep(0.5);
+    }
+}
+
+int main(int argc, char *argv[]) {
+    char interface_name[128] = {0};
+    if (argc == 2) {
+        strcpy(interface_name, argv[1]);
+    } else {
+        strcpy(interface_name, "wlp59s0");
+    }
+    printf("Using interface_name: %s\n", interface_name);
+
+    pthread_mutex_init(&owq_mutex, NULL);
+
+    test_threads(interface_name);
+
+    return 0;
+}

--- a/owfuzz/src/tests/test_wi_write.c
+++ b/owfuzz/src/tests/test_wi_write.c
@@ -1,4 +1,4 @@
-#include <stddef.h>
+#include <utypes.h>
 #include <string.h>
 #include <assert.h>
 #include <stdio.h>
@@ -14,10 +14,8 @@ void test_single_wi_write(char *iface) {
     pkt.channel = 7;
 
     struct wif * wi = wi_open(iface);
-    if (wi == NULL) {
-        assert("Failed to open interface");
-    }
-    printf("wi_open successfulL %08X\n", wi);
+    assert (wi != NULL && "Failed to open interface");
+    printf("wi_open successfull %08X\n", wi);
 
     struct devices dev;
     memset(&dev, 0, sizeof(struct devices));
@@ -25,11 +23,8 @@ void test_single_wi_write(char *iface) {
     dev.fd_out = wi_fd(wi);
     printf("wi_fd successful: %d\n", dev.fd_out);
 
-    int res = 0;
-    if (-1 == (res = wi_write(wi, pkt.data, pkt.len, NULL)))
-    {
-        assert("Failed to wi_write");
-    }
+    int res = wi_write(wi, pkt.data, pkt.len, NULL);
+    assert(res != -1 && "Failed to wi_write");
     printf("wi_write successful: %d\n", res);
 
     wi_close(wi);
@@ -45,9 +40,8 @@ void test_multi_wi_write(char *iface) {
     pkt.channel = 7;
 
     struct wif * wi = wi_open(iface);
-    if (wi == NULL) {
-        assert("Failed to open interface");
-    }
+    assert (wi != NULL && "Failed to open interface");
+
     printf("wi_open successfulL %08X\n", wi);
 
     struct devices dev;
@@ -57,11 +51,8 @@ void test_multi_wi_write(char *iface) {
     printf("wi_fd successful: %d\n", dev.fd_out);
 
     for (int i = 0; i < 1000; i++) {
-        int res = 0;
-        if (-1 == (res = wi_write(wi, pkt.data, pkt.len, NULL)))
-        {
-            assert("Failed to wi_write");
-        }
+        int res = wi_write(wi, pkt.data, pkt.len, NULL);
+        assert(res != -1 && "Failed to wi_write");
         printf("wi_write successful: %d (%d out of 1000)\r", res, i);
     }
     printf("\n");
@@ -72,10 +63,13 @@ void test_multi_wi_write(char *iface) {
 
 
 int main(int argc, char *argv[]) {
-    char interface_name[128] = {"wlp59s0"};
+    char interface_name[128] = {0};
     if (argc == 2) {
         strcpy(interface_name, argv[1]);
+    } else {
+        strcpy(interface_name, "wlp59s0");
     }
+    printf("Using interface_name: %s\n", interface_name);
     printf("\nStarting test_single_wi_write\n");
     test_single_wi_write(interface_name);
 

--- a/owfuzz/src/tests/test_wi_write.c
+++ b/owfuzz/src/tests/test_wi_write.c
@@ -71,11 +71,17 @@ void test_multi_wi_write(char *iface) {
 }
 
 
-void main() {
+int main(int argc, char *argv[]) {
+    char interface_name[128] = {"wlp59s0"};
+    if (argc == 2) {
+        strcpy(interface_name, argv[1]);
+    }
     printf("\nStarting test_single_wi_write\n");
-    test_single_wi_write("wlp59s0");
+    test_single_wi_write(interface_name);
 
     printf("\nStarting test_multi_wi_write\n");
-    test_multi_wi_write("wlp59s0");
+    test_multi_wi_write(interface_name);
+
+    return 0;
 }
 

--- a/owfuzz/src/tests/test_wi_write.c
+++ b/owfuzz/src/tests/test_wi_write.c
@@ -15,7 +15,7 @@ void test_single_wi_write(char *iface) {
 
     struct wif * wi = wi_open(iface);
     assert (wi != NULL && "Failed to open interface");
-    printf("wi_open successfull %08X\n", wi);
+    printf("wi_open successful %08X\n", wi);
 
     struct devices dev;
     memset(&dev, 0, sizeof(struct devices));
@@ -42,7 +42,7 @@ void test_multi_wi_write(char *iface) {
     struct wif * wi = wi_open(iface);
     assert (wi != NULL && "Failed to open interface");
 
-    printf("wi_open successfulL %08X\n", wi);
+    printf("wi_open successful %08X\n", wi);
 
     struct devices dev;
     memset(&dev, 0, sizeof(struct devices));

--- a/owfuzz/src/tests/test_wi_write.c
+++ b/owfuzz/src/tests/test_wi_write.c
@@ -1,0 +1,81 @@
+#include <stddef.h>
+#include <string.h>
+#include <assert.h>
+#include <stdio.h>
+
+#include "osdep_wifi_transmit.h"
+
+void test_single_wi_write(char *iface) {
+    struct packet pkt;
+
+    memset(&pkt, 0, sizeof(struct packet));
+    strncpy(pkt.data, "HELLO", strlen("HELLO"));
+    pkt.len = strlen("HELLO");
+    pkt.channel = 7;
+
+    struct wif * wi = wi_open(iface);
+    if (wi == NULL) {
+        assert("Failed to open interface");
+    }
+    printf("wi_open successfulL %08X\n", wi);
+
+    struct devices dev;
+    memset(&dev, 0, sizeof(struct devices));
+
+    dev.fd_out = wi_fd(wi);
+    printf("wi_fd successful: %d\n", dev.fd_out);
+
+    int res = 0;
+    if (-1 == (res = wi_write(wi, pkt.data, pkt.len, NULL)))
+    {
+        assert("Failed to wi_write");
+    }
+    printf("wi_write successful: %d\n", res);
+
+    wi_close(wi);
+    printf("wi_close successful\n");
+}
+
+void test_multi_wi_write(char *iface) {
+    struct packet pkt;
+
+    memset(&pkt, 0, sizeof(struct packet));
+    strncpy(pkt.data, "HELLO", strlen("HELLO"));
+    pkt.len = strlen("HELLO");
+    pkt.channel = 7;
+
+    struct wif * wi = wi_open(iface);
+    if (wi == NULL) {
+        assert("Failed to open interface");
+    }
+    printf("wi_open successfulL %08X\n", wi);
+
+    struct devices dev;
+    memset(&dev, 0, sizeof(struct devices));
+
+    dev.fd_out = wi_fd(wi);
+    printf("wi_fd successful: %d\n", dev.fd_out);
+
+    for (int i = 0; i < 1000; i++) {
+        int res = 0;
+        if (-1 == (res = wi_write(wi, pkt.data, pkt.len, NULL)))
+        {
+            assert("Failed to wi_write");
+        }
+        printf("wi_write successful: %d (%d out of 1000)\r", res, i);
+    }
+    printf("\n");
+
+    wi_close(wi);
+    printf("wi_close successful\n");
+}
+
+
+void main() {
+    printf("\nStarting test_single_wi_write\n");
+    test_single_wi_write("wlp59s0");
+
+    printf("\nStarting test_multi_wi_write\n");
+    test_multi_wi_write("wlp59s0");
+}
+


### PR DESCRIPTION
1. SSID may have spaces in them, support it
2. Provide names for the WPA States, allows for easier debugging
3. Provide Frame Name in the printf
4. Reduce verbosity noise by having a hashtable and not notify MACs we gave notifications for before
5. Provide user with information when the configuration we gave is unlikely to work
6. Show the progress by showing pkt_fuzzed_count
7. `.gitignore` compiled files
8. Prevent going into an endless loop if no pkts are found
9. Add 'unitest' for the HW used (wi_write, wi_read and wi_loop)