### PR TITLE
Fix pcap write and improve appending of new packets to existing pcap …

### DIFF
--- a/owfuzz/src/common/pcap_log.c
+++ b/owfuzz/src/common/pcap_log.c
@@ -46,7 +46,7 @@ int open_pcap()
         return 0;
     }
 
-    pcap_fp = pcap_dump_open(p, owfuzz_path);
+    pcap_fp = pcap_dump_open_append(p, owfuzz_path);
     if (NULL == pcap_fp)
     {
         fuzz_logger_log(FUZZ_LOG_ERR, "pcap_dump_open failed");

--- a/owfuzz/src/fuzz_control.c
+++ b/owfuzz/src/fuzz_control.c
@@ -2608,7 +2608,9 @@ void save_exp_payload(struct packet *pkt)
 
 	fuzzing_opt.fuzz_exp_pkt_cnt++;
 
+	open_pcap();
 	write_pcap(pkt->data, pkt->len);
+	close_pcap();
 
 	fd = open(owfuzz_path, O_RDWR | O_CREAT | O_APPEND | O_SYNC, 0);
 	if (pkt->len)


### PR DESCRIPTION
Hi I suggest following patch. I was not seeing open_pcap() function invocation in fuzz_control.c. I added it and also changed it to append packets instead overwriting pcap. Without open_pcap() I was not seeing pcap file generated during fuzzing when PoC was detected.